### PR TITLE
feat(mcp): SSE server transport for HTTP-based MCP

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,9 @@ backoff = { version = "0.4", features = ["tokio"] }
 # UUID
 uuid = { version = "1.8", features = ["v4", "serde"] }
 
+# Web framework
+axum = { version = "0.7", features = ["macros"] }
+
 # Random
 rand = "0.8"
 

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -25,3 +25,10 @@ tokio-util = { version = "0.7", features = ["codec"] }
 # For SSE transport
 reqwest = { workspace = true }
 eventsource-client = "0.13"
+
+# For SSE server transport
+axum = { workspace = true }
+tower = "0.5"
+tower-http = { version = "0.6", features = ["cors"] }
+async-stream = { workspace = true }
+http = "1.0"

--- a/crates/mcp/README.md
+++ b/crates/mcp/README.md
@@ -78,6 +78,37 @@ let server = McpServer::builder()
 server.run_stdio().await?;
 ```
 
+### Server: HTTP/SSE Transport
+
+For web-based clients, use the SSE transport:
+
+```rust
+use rust_ai_agents_mcp::{McpServer, SseServerConfig};
+
+let server = McpServer::builder()
+    .name("my-sse-server")
+    .version("1.0.0")
+    .add_tool(MyTool)
+    .build();
+
+// Configure SSE server
+let config = SseServerConfig {
+    host: "127.0.0.1".to_string(),
+    port: 3000,
+    sse_path: "/sse".to_string(),
+    message_path: "/message".to_string(),
+    enable_cors: true,
+    keep_alive_secs: 30,
+};
+
+// Run HTTP server (blocks until shutdown)
+server.run_sse(config).await?;
+```
+
+Endpoints:
+- `GET /sse` - SSE stream for server-to-client messages
+- `POST /message?sessionId=xxx` - JSON-RPC requests from client
+
 ## Using with Claude Desktop
 
 1. Build your MCP server:
@@ -208,13 +239,17 @@ pub trait PromptHandler: Send + Sync {
 
 See the examples directory:
 
-- `examples/mcp_server.rs` - Complete MCP server with demo tools
+- `examples/mcp_server.rs` - MCP server with STDIO transport (for Claude Desktop)
+- `examples/mcp_sse_server.rs` - MCP server with HTTP/SSE transport (for web clients)
 - `examples/mcp_integration.rs` - Client connecting to external MCP servers
 
 Run examples:
 ```bash
-# Server example
+# STDIO server example (for Claude Desktop)
 cargo run --example mcp_server
+
+# SSE server example (HTTP on port 3000)
+cargo run --example mcp_sse_server
 
 # Client example (requires Node.js/npx)
 cargo run --example mcp_integration

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -33,6 +33,7 @@ pub mod client;
 pub mod error;
 pub mod protocol;
 pub mod server;
+pub mod sse_server;
 pub mod transport;
 
 pub use bridge::McpToolBridge;
@@ -43,4 +44,5 @@ pub use server::{
     AsyncFnTool, FnTool, McpServer, McpServerBuilder, PromptContent, PromptHandler, PromptMessage,
     ResourceHandler, ServerConfig, ToolHandler,
 };
+pub use sse_server::SseServerConfig;
 pub use transport::{McpTransport, SseTransport, StdioTransport};

--- a/crates/mcp/src/sse_server.rs
+++ b/crates/mcp/src/sse_server.rs
@@ -1,0 +1,443 @@
+//! SSE Server Transport for MCP
+//!
+//! Implements HTTP-based MCP server transport using Server-Sent Events (SSE)
+//! for server-to-client communication and POST requests for client-to-server.
+//!
+//! # Architecture
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────┐
+//! │                     SSE Server Transport                     │
+//! ├─────────────────────────────────────────────────────────────┤
+//! │                                                              │
+//! │  GET /sse ─────────────► SSE Stream (server→client)         │
+//! │                          - Sends endpoint event first       │
+//! │                          - Then streams responses           │
+//! │                                                              │
+//! │  POST /message ────────► JSON-RPC Request (client→server)   │
+//! │                          - Returns immediately              │
+//! │                          - Response sent via SSE            │
+//! │                                                              │
+//! └─────────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use rust_ai_agents_mcp::{McpServer, SseServerConfig};
+//!
+//! let server = McpServer::builder()
+//!     .name("my-server")
+//!     .add_tool(my_tool)
+//!     .build();
+//!
+//! // Run with SSE transport on port 3000
+//! server.run_sse(SseServerConfig::default()).await?;
+//! ```
+
+use axum::{
+    extract::State,
+    http::{header, Method},
+    response::sse::{Event, KeepAlive, Sse},
+    routing::{get, post},
+    Json, Router,
+};
+use futures::stream::Stream;
+use http::StatusCode;
+use parking_lot::RwLock;
+use std::collections::HashMap;
+use std::convert::Infallible;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::sync::{broadcast, mpsc};
+use tower_http::cors::{Any, CorsLayer};
+use tracing::{debug, error, info};
+use uuid::Uuid;
+
+use crate::error::McpError;
+use crate::protocol::JsonRpcResponse;
+use crate::server::McpServer;
+
+// =============================================================================
+// SSE Server Configuration
+// =============================================================================
+
+/// Configuration for the SSE server transport
+#[derive(Debug, Clone)]
+pub struct SseServerConfig {
+    /// Host to bind to
+    pub host: String,
+    /// Port to bind to
+    pub port: u16,
+    /// Path for SSE endpoint
+    pub sse_path: String,
+    /// Path for message endpoint
+    pub message_path: String,
+    /// Enable CORS
+    pub enable_cors: bool,
+    /// Keep-alive interval in seconds
+    pub keep_alive_secs: u64,
+}
+
+impl Default for SseServerConfig {
+    fn default() -> Self {
+        Self {
+            host: "127.0.0.1".to_string(),
+            port: 3000,
+            sse_path: "/sse".to_string(),
+            message_path: "/message".to_string(),
+            enable_cors: true,
+            keep_alive_secs: 30,
+        }
+    }
+}
+
+impl SseServerConfig {
+    /// Create config for localhost on specified port
+    pub fn localhost(port: u16) -> Self {
+        Self {
+            port,
+            ..Default::default()
+        }
+    }
+
+    /// Create config that binds to all interfaces
+    pub fn public(port: u16) -> Self {
+        Self {
+            host: "0.0.0.0".to_string(),
+            port,
+            ..Default::default()
+        }
+    }
+}
+
+// =============================================================================
+// SSE Server State
+// =============================================================================
+
+/// Internal state for SSE server
+struct SseServerState {
+    /// Reference to the MCP server
+    mcp_server: Arc<McpServer>,
+    /// Configuration
+    config: SseServerConfig,
+    /// Active SSE sessions: session_id -> response sender
+    sessions: RwLock<HashMap<String, mpsc::Sender<JsonRpcResponse>>>,
+    /// Broadcast channel for shutdown
+    shutdown_tx: broadcast::Sender<()>,
+}
+
+impl SseServerState {
+    fn new(
+        mcp_server: Arc<McpServer>,
+        config: SseServerConfig,
+        shutdown_tx: broadcast::Sender<()>,
+    ) -> Self {
+        Self {
+            mcp_server,
+            config,
+            sessions: RwLock::new(HashMap::new()),
+            shutdown_tx,
+        }
+    }
+
+    fn register_session(&self, session_id: String, sender: mpsc::Sender<JsonRpcResponse>) {
+        self.sessions.write().insert(session_id, sender);
+    }
+
+    fn unregister_session(&self, session_id: &str) {
+        self.sessions.write().remove(session_id);
+    }
+
+    fn get_session_sender(&self, session_id: &str) -> Option<mpsc::Sender<JsonRpcResponse>> {
+        self.sessions.read().get(session_id).cloned()
+    }
+}
+
+// =============================================================================
+// SSE Server Extension for McpServer
+// =============================================================================
+
+impl McpServer {
+    /// Run the server with SSE transport
+    ///
+    /// This starts an HTTP server with:
+    /// - GET /sse - SSE endpoint for server-to-client streaming
+    /// - POST /message - Endpoint for client-to-server requests
+    pub async fn run_sse(self: Arc<Self>, config: SseServerConfig) -> Result<(), McpError> {
+        let (shutdown_tx, _) = broadcast::channel::<()>(1);
+        let state = Arc::new(SseServerState::new(
+            self.clone(),
+            config.clone(),
+            shutdown_tx,
+        ));
+
+        let mut app = Router::new()
+            .route(&config.sse_path, get(handle_sse))
+            .route(&config.message_path, post(handle_message))
+            .with_state(state.clone());
+
+        if config.enable_cors {
+            let cors = CorsLayer::new()
+                .allow_origin(Any)
+                .allow_methods([Method::GET, Method::POST])
+                .allow_headers([header::CONTENT_TYPE, header::ACCEPT]);
+            app = app.layer(cors);
+        }
+
+        let addr: SocketAddr = format!("{}:{}", config.host, config.port)
+            .parse()
+            .map_err(|e| McpError::Transport(format!("Invalid address: {}", e)))?;
+
+        info!(
+            "Starting MCP SSE server on http://{}{}",
+            addr, config.sse_path
+        );
+        info!("Message endpoint: http://{}{}", addr, config.message_path);
+
+        let listener = tokio::net::TcpListener::bind(addr)
+            .await
+            .map_err(|e| McpError::Transport(format!("Failed to bind: {}", e)))?;
+
+        axum::serve(listener, app)
+            .await
+            .map_err(|e| McpError::Transport(format!("Server error: {}", e)))?;
+
+        Ok(())
+    }
+
+    /// Run the server with SSE transport and return the router
+    /// (for embedding in existing Axum applications)
+    pub fn sse_router(self: Arc<Self>, config: SseServerConfig) -> Router {
+        let (shutdown_tx, _) = broadcast::channel::<()>(1);
+        let state = Arc::new(SseServerState::new(
+            self.clone(),
+            config.clone(),
+            shutdown_tx,
+        ));
+
+        let mut router = Router::new()
+            .route(&config.sse_path, get(handle_sse))
+            .route(&config.message_path, post(handle_message))
+            .with_state(state);
+
+        if config.enable_cors {
+            let cors = CorsLayer::new()
+                .allow_origin(Any)
+                .allow_methods([Method::GET, Method::POST])
+                .allow_headers([header::CONTENT_TYPE, header::ACCEPT]);
+            router = router.layer(cors);
+        }
+
+        router
+    }
+}
+
+// =============================================================================
+// Request/Response Types
+// =============================================================================
+
+/// SSE endpoint event - tells client where to POST messages
+#[derive(Debug, serde::Serialize)]
+struct EndpointEvent {
+    endpoint: String,
+}
+
+// =============================================================================
+// HTTP Handlers
+// =============================================================================
+
+/// Handle SSE connection
+async fn handle_sse(
+    State(state): State<Arc<SseServerState>>,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    let session_id = Uuid::new_v4().to_string();
+    let (tx, mut rx) = mpsc::channel::<JsonRpcResponse>(100);
+
+    state.register_session(session_id.clone(), tx);
+
+    let config = state.config.clone();
+    let state_clone = state.clone();
+    let session_id_clone = session_id.clone();
+
+    info!("New SSE session: {}", session_id);
+
+    let stream = async_stream::stream! {
+        // First, send the endpoint event
+        let endpoint = EndpointEvent {
+            endpoint: format!("{}?sessionId={}", config.message_path, session_id_clone),
+        };
+        let endpoint_json = serde_json::to_string(&endpoint).unwrap();
+        yield Ok(Event::default().event("endpoint").data(endpoint_json));
+
+        debug!("Sent endpoint event for session {}", session_id_clone);
+
+        // Then stream responses
+        let mut shutdown_rx = state_clone.shutdown_tx.subscribe();
+        loop {
+            tokio::select! {
+                Some(response) = rx.recv() => {
+                    match serde_json::to_string(&response) {
+                        Ok(json) => {
+                            debug!("Sending SSE message: {}", json);
+                            yield Ok(Event::default().event("message").data(json));
+                        }
+                        Err(e) => {
+                            error!("Failed to serialize response: {}", e);
+                        }
+                    }
+                }
+                _ = shutdown_rx.recv() => {
+                    info!("SSE session {} shutting down", session_id_clone);
+                    break;
+                }
+            }
+        }
+
+        state_clone.unregister_session(&session_id_clone);
+        info!("SSE session {} closed", session_id_clone);
+    };
+
+    Sse::new(stream).keep_alive(
+        KeepAlive::new()
+            .interval(std::time::Duration::from_secs(state.config.keep_alive_secs))
+            .text("ping"),
+    )
+}
+
+/// Query parameters for message endpoint
+#[derive(Debug, Default, serde::Deserialize)]
+struct MessageQuery {
+    #[serde(rename = "sessionId")]
+    session_id: Option<String>,
+}
+
+/// Handle incoming JSON-RPC message
+async fn handle_message(
+    State(state): State<Arc<SseServerState>>,
+    axum::extract::Query(query): axum::extract::Query<MessageQuery>,
+    Json(body): Json<serde_json::Value>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let session_id = query.session_id;
+
+    debug!(
+        "Received message for session {:?}: {}",
+        session_id,
+        serde_json::to_string_pretty(&body).unwrap_or_default()
+    );
+
+    // Parse as JSON-RPC request
+    let request = match serde_json::from_value::<crate::protocol::JsonRpcRequest>(body.clone()) {
+        Ok(req) => req,
+        Err(e) => {
+            error!("Failed to parse JSON-RPC request: {}", e);
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": null,
+                    "error": {
+                        "code": -32700,
+                        "message": format!("Parse error: {}", e)
+                    }
+                })),
+            );
+        }
+    };
+
+    // Handle the request
+    let response = state.mcp_server.handle_request(request).await;
+
+    // If we have a session, send via SSE; otherwise return directly
+    if let Some(ref sid) = session_id {
+        if let Some(sender) = state.get_session_sender(sid) {
+            if sender.send(response.clone()).await.is_ok() {
+                // Return accepted - response will come via SSE
+                return (
+                    StatusCode::ACCEPTED,
+                    Json(serde_json::json!({"status": "accepted"})),
+                );
+            }
+        }
+    }
+
+    // No session or send failed - return response directly
+    let response_json = serde_json::to_value(&response).unwrap_or_default();
+    (StatusCode::OK, Json(response_json))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::FnTool;
+    use serde_json::json;
+
+    fn create_test_server() -> Arc<McpServer> {
+        McpServer::builder()
+            .name("test-sse-server")
+            .version("1.0.0")
+            .add_tool(FnTool::new(
+                "echo",
+                "Echoes input",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "message": {"type": "string"}
+                    }
+                }),
+                |args| {
+                    let msg = args["message"].as_str().unwrap_or("no message");
+                    Ok(json!({"echoed": msg}))
+                },
+            ))
+            .build()
+    }
+
+    #[test]
+    fn test_sse_config_default() {
+        let config = SseServerConfig::default();
+        assert_eq!(config.host, "127.0.0.1");
+        assert_eq!(config.port, 3000);
+        assert_eq!(config.sse_path, "/sse");
+        assert_eq!(config.message_path, "/message");
+        assert!(config.enable_cors);
+    }
+
+    #[test]
+    fn test_sse_config_localhost() {
+        let config = SseServerConfig::localhost(8080);
+        assert_eq!(config.host, "127.0.0.1");
+        assert_eq!(config.port, 8080);
+    }
+
+    #[test]
+    fn test_sse_config_public() {
+        let config = SseServerConfig::public(9000);
+        assert_eq!(config.host, "0.0.0.0");
+        assert_eq!(config.port, 9000);
+    }
+
+    #[tokio::test]
+    async fn test_sse_router_creation() {
+        let server = create_test_server();
+        let config = SseServerConfig::default();
+        let _router = server.sse_router(config);
+        // Router created successfully
+    }
+
+    #[tokio::test]
+    async fn test_session_registration() {
+        let server = create_test_server();
+        let (shutdown_tx, _) = broadcast::channel::<()>(1);
+        let state = SseServerState::new(server, SseServerConfig::default(), shutdown_tx);
+
+        let (tx, _rx) = mpsc::channel::<JsonRpcResponse>(10);
+        state.register_session("test-session".to_string(), tx);
+
+        assert!(state.get_session_sender("test-session").is_some());
+        assert!(state.get_session_sender("nonexistent").is_none());
+
+        state.unregister_session("test-session");
+        assert!(state.get_session_sender("test-session").is_none());
+    }
+}

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -67,3 +67,7 @@ path = "mcp_integration.rs"
 [[example]]
 name = "mcp_server"
 path = "mcp_server.rs"
+
+[[example]]
+name = "mcp_sse_server"
+path = "mcp_sse_server.rs"

--- a/examples/mcp_sse_server.rs
+++ b/examples/mcp_sse_server.rs
@@ -1,0 +1,291 @@
+//! MCP SSE Server Example
+//!
+//! This example demonstrates how to create an MCP server that exposes
+//! tools via HTTP/SSE transport instead of STDIO.
+//!
+//! # Running the Example
+//!
+//! ```bash
+//! cargo run --example mcp_sse_server
+//! ```
+//!
+//! The server will start on http://localhost:3000
+//!
+//! # Endpoints
+//!
+//! - `GET /sse` - SSE endpoint for server-to-client streaming
+//! - `POST /message?sessionId=xxx` - JSON-RPC requests from client
+//!
+//! # Testing
+//!
+//! 1. Connect to SSE endpoint:
+//!    ```bash
+//!    curl -N http://localhost:3000/sse
+//!    ```
+//!    You'll receive an "endpoint" event with the POST URL.
+//!
+//! 2. Send a request (replace SESSION_ID with actual value):
+//!    ```bash
+//!    curl -X POST "http://localhost:3000/message?sessionId=SESSION_ID" \
+//!      -H "Content-Type: application/json" \
+//!      -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+//!    ```
+//!
+//! # What This Example Does
+//!
+//! Creates an MCP server with demo tools accessible via HTTP:
+//! - `echo`: Simple echo tool
+//! - `calculate`: Basic calculator
+//! - `get_time`: Returns current time
+
+use async_trait::async_trait;
+use rust_ai_agents_mcp::{
+    CallToolResult, McpError, McpServer, McpTool, SseServerConfig, ToolContent, ToolHandler,
+};
+use serde_json::json;
+use tracing::info;
+
+// =============================================================================
+// Tool Implementations
+// =============================================================================
+
+/// Echo tool - returns the input message
+struct EchoTool;
+
+#[async_trait]
+impl ToolHandler for EchoTool {
+    fn definition(&self) -> McpTool {
+        McpTool {
+            name: "echo".to_string(),
+            description: Some("Echoes back the provided message".to_string()),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "message": {
+                        "type": "string",
+                        "description": "The message to echo back"
+                    }
+                },
+                "required": ["message"]
+            }),
+        }
+    }
+
+    async fn execute(&self, arguments: serde_json::Value) -> Result<CallToolResult, McpError> {
+        let message = arguments
+            .get("message")
+            .and_then(|v| v.as_str())
+            .unwrap_or("No message provided");
+
+        Ok(CallToolResult {
+            content: vec![ToolContent::text(format!("Echo: {}", message))],
+            is_error: false,
+        })
+    }
+}
+
+/// Calculator tool - performs basic math operations
+struct CalculatorTool;
+
+#[async_trait]
+impl ToolHandler for CalculatorTool {
+    fn definition(&self) -> McpTool {
+        McpTool {
+            name: "calculate".to_string(),
+            description: Some("Performs basic mathematical operations".to_string()),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "operation": {
+                        "type": "string",
+                        "enum": ["add", "subtract", "multiply", "divide"],
+                        "description": "The operation to perform"
+                    },
+                    "a": {
+                        "type": "number",
+                        "description": "First operand"
+                    },
+                    "b": {
+                        "type": "number",
+                        "description": "Second operand"
+                    }
+                },
+                "required": ["operation", "a", "b"]
+            }),
+        }
+    }
+
+    async fn execute(&self, arguments: serde_json::Value) -> Result<CallToolResult, McpError> {
+        let operation = arguments
+            .get("operation")
+            .and_then(|v| v.as_str())
+            .unwrap_or("add");
+
+        let a = arguments.get("a").and_then(|v| v.as_f64()).unwrap_or(0.0);
+        let b = arguments.get("b").and_then(|v| v.as_f64()).unwrap_or(0.0);
+
+        let result = match operation {
+            "add" => Ok(a + b),
+            "subtract" => Ok(a - b),
+            "multiply" => Ok(a * b),
+            "divide" => {
+                if b == 0.0 {
+                    Err("Division by zero")
+                } else {
+                    Ok(a / b)
+                }
+            }
+            _ => Err("Unknown operation"),
+        };
+
+        match result {
+            Ok(value) => Ok(CallToolResult {
+                content: vec![ToolContent::text(format!(
+                    "{} {} {} = {}",
+                    a, operation, b, value
+                ))],
+                is_error: false,
+            }),
+            Err(e) => Ok(CallToolResult {
+                content: vec![ToolContent::text(e.to_string())],
+                is_error: true,
+            }),
+        }
+    }
+}
+
+/// Time tool - returns the current time
+struct TimeTool;
+
+#[async_trait]
+impl ToolHandler for TimeTool {
+    fn definition(&self) -> McpTool {
+        McpTool {
+            name: "get_time".to_string(),
+            description: Some("Returns the current date and time".to_string()),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "format": {
+                        "type": "string",
+                        "enum": ["iso", "human", "unix"],
+                        "description": "Output format (default: human)",
+                        "default": "human"
+                    }
+                }
+            }),
+        }
+    }
+
+    async fn execute(&self, arguments: serde_json::Value) -> Result<CallToolResult, McpError> {
+        let format = arguments
+            .get("format")
+            .and_then(|v| v.as_str())
+            .unwrap_or("human");
+
+        let now = chrono::Utc::now();
+
+        let formatted = match format {
+            "iso" => now.to_rfc3339(),
+            "unix" => now.timestamp().to_string(),
+            _ => now.format("%Y-%m-%d %H:%M:%S UTC").to_string(),
+        };
+
+        Ok(CallToolResult {
+            content: vec![ToolContent::text(formatted)],
+            is_error: false,
+        })
+    }
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Initialize logging
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .init();
+
+    info!("Starting rust-ai-agents MCP SSE Server");
+
+    // Build the MCP server with our tools
+    let server = McpServer::builder()
+        .name("rust-ai-agents-sse-demo")
+        .version(env!("CARGO_PKG_VERSION"))
+        .instructions("Demo MCP server over HTTP/SSE. Tools: echo, calculate, get_time")
+        .add_tool(EchoTool)
+        .add_tool(CalculatorTool)
+        .add_tool(TimeTool)
+        .build();
+
+    // Configure SSE server
+    let config = SseServerConfig {
+        host: "127.0.0.1".to_string(),
+        port: 3000,
+        sse_path: "/sse".to_string(),
+        message_path: "/message".to_string(),
+        enable_cors: true,
+        keep_alive_secs: 30,
+    };
+
+    info!("Server configured with 3 tools");
+    info!(
+        "SSE endpoint: http://{}:{}{}",
+        config.host, config.port, config.sse_path
+    );
+    info!(
+        "Message endpoint: http://{}:{}{}",
+        config.host, config.port, config.message_path
+    );
+
+    // Run the server (blocks until shutdown)
+    server.run_sse(config).await?;
+
+    info!("Server shutting down");
+    Ok(())
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_echo_tool() {
+        let tool = EchoTool;
+        let result = tool.execute(json!({"message": "Hello SSE"})).await.unwrap();
+        assert!(!result.is_error);
+        assert_eq!(result.content[0].as_text().unwrap(), "Echo: Hello SSE");
+    }
+
+    #[tokio::test]
+    async fn test_calculator_multiply() {
+        let tool = CalculatorTool;
+        let result = tool
+            .execute(json!({
+                "operation": "multiply",
+                "a": 7,
+                "b": 6
+            }))
+            .await
+            .unwrap();
+        assert!(!result.is_error);
+        assert!(result.content[0].as_text().unwrap().contains("42"));
+    }
+
+    #[tokio::test]
+    async fn test_time_tool() {
+        let tool = TimeTool;
+        let result = tool.execute(json!({"format": "unix"})).await.unwrap();
+        assert!(!result.is_error);
+        // Should be a number (Unix timestamp)
+        let text = result.content[0].as_text().unwrap();
+        assert!(text.parse::<i64>().is_ok());
+    }
+}


### PR DESCRIPTION
## Summary

Implements HTTP/SSE transport for McpServer, allowing MCP tools to be exposed via HTTP endpoints instead of STDIO. This enables web-based clients to connect to MCP servers.

## Changes

### New Features
- `SseServerConfig` for configuring host, port, paths, CORS
- `GET /sse` endpoint for SSE streaming (server-to-client)
- `POST /message?sessionId=xxx` for JSON-RPC requests (client-to-server)
- Session management for multiple concurrent clients
- `run_sse()` method on McpServer for standalone HTTP server
- `sse_router()` method for embedding in existing Axum apps

### Files Changed
- `crates/mcp/src/sse_server.rs` - Full SSE server implementation
- `crates/mcp/src/server.rs` - Fix parking_lot lock Send issues
- `crates/mcp/src/lib.rs` - Export new module
- `crates/mcp/Cargo.toml` - Add axum, tower, tower-http, http deps
- `examples/mcp_sse_server.rs` - Example demonstrating HTTP transport
- `crates/mcp/README.md` - Documentation for SSE transport

## Testing

```bash
# Run the SSE server example
cargo run --example mcp_sse_server

# In another terminal, test SSE connection
curl -N http://localhost:3000/sse

# Send a request (replace SESSION_ID)
curl -X POST "http://localhost:3000/message?sessionId=SESSION_ID" \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
```

## Closes

Closes #3