### PR TITLE
docs: Add LLM Backends and Approvals guides

### DIFF
--- a/crates/mcp/src/session_resources.rs
+++ b/crates/mcp/src/session_resources.rs
@@ -161,11 +161,7 @@ impl<S: SessionStoreRead + 'static> ResourceHandler for SessionResourceHandler<S
 
         match parts {
             SessionUriParts::List => {
-                let ids = self
-                    .store
-                    .list_ids()
-                    .await
-                    .map_err(|e| McpError::Internal(e))?;
+                let ids = self.store.list_ids().await.map_err(McpError::Internal)?;
 
                 let mut sessions = Vec::new();
                 for id in ids.into_iter().take(self.max_list_size) {
@@ -196,7 +192,7 @@ impl<S: SessionStoreRead + 'static> ResourceHandler for SessionResourceHandler<S
                     .store
                     .load_json(&session_id)
                     .await
-                    .map_err(|e| McpError::Internal(e))?
+                    .map_err(McpError::Internal)?
                     .ok_or_else(|| {
                         McpError::ResourceNotFound(format!("Session not found: {}", session_id))
                     })?;
@@ -214,7 +210,7 @@ impl<S: SessionStoreRead + 'static> ResourceHandler for SessionResourceHandler<S
                     .store
                     .get_messages_json(&session_id)
                     .await
-                    .map_err(|e| McpError::Internal(e))?
+                    .map_err(McpError::Internal)?
                     .ok_or_else(|| {
                         McpError::ResourceNotFound(format!("Session not found: {}", session_id))
                     })?;
@@ -232,7 +228,7 @@ impl<S: SessionStoreRead + 'static> ResourceHandler for SessionResourceHandler<S
                     .store
                     .get_turn_json(&session_id, turn_number)
                     .await
-                    .map_err(|e| McpError::Internal(e))?
+                    .map_err(McpError::Internal)?
                     .ok_or_else(|| {
                         McpError::ResourceNotFound(format!(
                             "Turn {} not found in session {}",

--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -1,0 +1,467 @@
+# Approvals and Safety Sandwich Guide
+
+This guide covers the human-in-the-loop approval system and the Safety Sandwich architecture pattern in HyperAgent.
+
+## Overview
+
+HyperAgent implements a multi-layered safety system that intercepts dangerous operations and requires human approval before execution.
+
+## Safety Sandwich Architecture
+
+The Safety Sandwich wraps tool execution with input/output validation and approval gates:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     SAFETY SANDWICH                         │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│  1. INPUT GUARDRAILS                                        │
+│     ├── Validate user input                                 │
+│     ├── Check for prompt injection                          │
+│     └── Sanitize dangerous patterns                         │
+│                         ↓                                   │
+│  2. APPROVAL GATE (if tool.dangerous = true)                │
+│     ├── Show tool call details to human                     │
+│     ├── Wait for approval/denial                            │
+│     └── Allow argument modification                         │
+│                         ↓                                   │
+│  3. TOOL EXECUTOR                                           │
+│     ├── Execute approved tool                               │
+│     └── Capture output                                      │
+│                         ↓                                   │
+│  4. OUTPUT GUARDRAILS                                       │
+│     ├── Validate tool output                                │
+│     ├── Check for sensitive data leakage                    │
+│     └── Sanitize response                                   │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Quick Start
+
+```rust
+use rust_ai_agents_agents::approvals::{ApprovalConfig, TerminalApprovalHandler};
+
+// Configure approval requirements
+let config = ApprovalConfig::builder()
+    .require_approval_for_dangerous(true)
+    .always_approve_tools(vec!["read_file", "search"])
+    .always_deny_tools(vec!["delete_all", "format_disk"])
+    .build();
+
+// Create handler for terminal interaction
+let handler = TerminalApprovalHandler::new(config);
+
+// Use with agent
+let agent = AgentBuilder::new()
+    .backend(backend)
+    .approval_handler(handler)
+    .build();
+```
+
+## Approval Configuration
+
+### ApprovalConfig
+
+```rust
+pub struct ApprovalConfig {
+    /// Require approval for tools marked as dangerous
+    pub require_approval_for_dangerous: bool,
+    
+    /// Require approval for ALL tool calls
+    pub require_approval_for_all: bool,
+    
+    /// Tools that bypass approval (whitelist)
+    pub always_approve_tools: HashSet<String>,
+    
+    /// Tools that are always denied (blacklist)
+    pub always_deny_tools: HashSet<String>,
+    
+    /// Regex patterns requiring approval
+    pub approval_patterns: Vec<String>,
+    
+    /// Timeout in seconds (0 = no timeout)
+    pub timeout_seconds: u64,
+    
+    /// Max pending approvals before auto-deny
+    pub max_pending_approvals: usize,
+}
+```
+
+### Builder Pattern
+
+```rust
+let config = ApprovalConfig::builder()
+    // Require approval for dangerous tools (default: true)
+    .require_approval_for_dangerous(true)
+    
+    // Or require approval for ALL tools
+    .require_approval_for_all(true)
+    
+    // Whitelist safe tools
+    .always_approve_tools(vec![
+        "read_file",
+        "list_directory",
+        "search",
+    ])
+    
+    // Blacklist dangerous tools
+    .always_deny_tools(vec![
+        "delete_all",
+        "execute_arbitrary_code",
+    ])
+    
+    // Pattern-based rules
+    .approval_pattern(".*_delete$")  // Anything ending in _delete
+    .approval_pattern("^admin_.*")   // Anything starting with admin_
+    
+    // Timeout (0 = wait forever)
+    .timeout_seconds(60)
+    
+    // Max pending approvals
+    .max_pending_approvals(10)
+    
+    .build();
+```
+
+## Approval Handlers
+
+### TerminalApprovalHandler
+
+Interactive approval via command line:
+
+```rust
+use rust_ai_agents_agents::approvals::TerminalApprovalHandler;
+
+let handler = TerminalApprovalHandler::new(config);
+
+// When a dangerous tool is called, user sees:
+// ┌─────────────────────────────────────────────────────────┐
+// │  APPROVAL REQUIRED                                      │
+// ├─────────────────────────────────────────────────────────┤
+// │  Tool: delete_file                                      │
+// │  Reason: Tool is marked as dangerous                    │
+// │                                                         │
+// │  Arguments:                                             │
+// │    {                                                    │
+// │      "path": "/etc/passwd"                              │
+// │    }                                                    │
+// │                                                         │
+// │  [A]pprove  [D]eny  [M]odify  [S]kip                   │
+// └─────────────────────────────────────────────────────────┘
+```
+
+### TestApprovalHandler
+
+For automated testing:
+
+```rust
+use rust_ai_agents_agents::approvals::TestApprovalHandler;
+
+// Auto-approve everything
+let handler = TestApprovalHandler::auto_approve();
+
+// Auto-deny everything  
+let handler = TestApprovalHandler::auto_deny();
+
+// Approve first N, then deny
+let handler = TestApprovalHandler::approve_first(3);
+
+// Custom decisions
+let handler = TestApprovalHandler::with_decisions(vec![
+    ApprovalDecision::Approved,
+    ApprovalDecision::Denied { reason: "Test".to_string() },
+    ApprovalDecision::Approved,
+]);
+
+// Verify approvals in tests
+#[tokio::test]
+async fn test_approval_flow() {
+    let handler = TestApprovalHandler::auto_approve();
+    
+    // ... run agent ...
+    
+    assert_eq!(handler.approval_count(), 2);
+    assert!(handler.was_tool_approved("dangerous_tool"));
+}
+```
+
+### AutoApproveHandler
+
+Bypass approvals entirely (use with caution):
+
+```rust
+use rust_ai_agents_agents::approvals::AutoApproveHandler;
+
+// Approve everything automatically
+let handler = AutoApproveHandler::new();
+
+// With logging
+let handler = AutoApproveHandler::with_logging();
+```
+
+### Custom Handler
+
+Implement your own approval logic:
+
+```rust
+use rust_ai_agents_agents::approvals::{ApprovalHandler, ApprovalRequest, ApprovalDecision};
+
+struct SlackApprovalHandler {
+    webhook_url: String,
+}
+
+#[async_trait]
+impl ApprovalHandler for SlackApprovalHandler {
+    async fn request_approval(
+        &self,
+        request: ApprovalRequest,
+    ) -> Result<ApprovalDecision, ApprovalError> {
+        // Send to Slack
+        let message = format!(
+            "Approval needed for tool `{}`\nArguments: {}",
+            request.tool_call.name,
+            serde_json::to_string_pretty(&request.tool_call.arguments)?
+        );
+        
+        // Post to Slack and wait for response
+        let response = self.post_and_wait(&message).await?;
+        
+        match response.as_str() {
+            "approve" => Ok(ApprovalDecision::Approved),
+            "deny" => Ok(ApprovalDecision::denied("Denied via Slack")),
+            _ => Ok(ApprovalDecision::Skip),
+        }
+    }
+}
+```
+
+## Approval Decisions
+
+```rust
+pub enum ApprovalDecision {
+    /// Proceed with execution
+    Approved,
+    
+    /// Do not execute
+    Denied { reason: String },
+    
+    /// Execute with modified arguments
+    Modify { new_arguments: serde_json::Value },
+    
+    /// Skip this tool but continue agent loop
+    Skip,
+}
+```
+
+### Modifying Arguments
+
+Users can modify tool arguments before approval:
+
+```rust
+// Original call: delete_file("/important/file.txt")
+// User modifies to: delete_file("/tmp/safe_file.txt")
+
+ApprovalDecision::Modify {
+    new_arguments: json!({
+        "path": "/tmp/safe_file.txt"
+    })
+}
+```
+
+## Marking Tools as Dangerous
+
+```rust
+use rust_ai_agents_core::Tool;
+
+// Using the dangerous flag
+let tool = Tool::new("delete_file", "Deletes a file")
+    .dangerous(true)  // Requires approval
+    .handler(|args| async { /* ... */ });
+
+// Safe tools don't require approval
+let tool = Tool::new("read_file", "Reads a file")
+    .dangerous(false)  // No approval needed (default)
+    .handler(|args| async { /* ... */ });
+```
+
+## Approval Reasons
+
+```rust
+pub enum ApprovalReason {
+    /// Tool has dangerous=true
+    DangerousTool,
+    
+    /// Tool name matches approval pattern
+    MatchesPattern(String),
+    
+    /// All tools require approval (config setting)
+    AllToolsRequireApproval,
+    
+    /// Custom reason
+    Custom(String),
+}
+```
+
+## Integration with AgentEngine
+
+```rust
+use rust_ai_agents_agents::{AgentEngine, AgentConfig};
+use rust_ai_agents_agents::approvals::{ApprovalConfig, TerminalApprovalHandler};
+
+// Configure agent with approvals
+let approval_config = ApprovalConfig::builder()
+    .require_approval_for_dangerous(true)
+    .timeout_seconds(120)
+    .build();
+
+let agent_config = AgentConfig::builder()
+    .name("secure-agent")
+    .approval_handler(TerminalApprovalHandler::new(approval_config))
+    .build();
+
+let engine = AgentEngine::new(backend, agent_config);
+
+// When agent calls a dangerous tool, approval is requested
+let result = engine.run("Delete the temp files").await?;
+```
+
+## Best Practices
+
+### 1. Defense in Depth
+
+Combine multiple safety layers:
+
+```rust
+let config = ApprovalConfig::builder()
+    // Layer 1: Blacklist known dangerous tools
+    .always_deny_tools(vec!["execute_shell", "sudo"])
+    
+    // Layer 2: Require approval for dangerous flag
+    .require_approval_for_dangerous(true)
+    
+    // Layer 3: Pattern matching for suspicious operations
+    .approval_pattern(".*delete.*")
+    .approval_pattern(".*remove.*")
+    .approval_pattern(".*drop.*")
+    
+    .build();
+```
+
+### 2. Principle of Least Privilege
+
+Only whitelist tools that are truly safe:
+
+```rust
+// Good: Specific whitelist
+.always_approve_tools(vec!["read_file", "search", "calculate"])
+
+// Bad: Too permissive
+.always_approve_tools(vec!["file_*"])  // Don't do this
+```
+
+### 3. Timeouts for Production
+
+Always set timeouts in production:
+
+```rust
+let config = ApprovalConfig::builder()
+    .timeout_seconds(300)  // 5 minute timeout
+    .build();
+```
+
+### 4. Audit Logging
+
+Log all approval decisions:
+
+```rust
+struct AuditedApprovalHandler<H: ApprovalHandler> {
+    inner: H,
+    logger: Logger,
+}
+
+#[async_trait]
+impl<H: ApprovalHandler> ApprovalHandler for AuditedApprovalHandler<H> {
+    async fn request_approval(&self, request: ApprovalRequest) -> Result<ApprovalDecision, ApprovalError> {
+        let decision = self.inner.request_approval(request.clone()).await?;
+        
+        self.logger.log(AuditEvent {
+            tool: request.tool_call.name,
+            arguments: request.tool_call.arguments,
+            decision: decision.clone(),
+            timestamp: Utc::now(),
+        });
+        
+        Ok(decision)
+    }
+}
+```
+
+## Example: Secure File Operations Agent
+
+```rust
+use rust_ai_agents_agents::approvals::{ApprovalConfig, TerminalApprovalHandler};
+
+// Define tools with appropriate danger levels
+let read_tool = Tool::new("read_file", "Read file contents")
+    .dangerous(false);
+
+let write_tool = Tool::new("write_file", "Write to file")
+    .dangerous(true);  // Requires approval
+
+let delete_tool = Tool::new("delete_file", "Delete a file")
+    .dangerous(true);  // Requires approval
+
+// Configure approvals
+let config = ApprovalConfig::builder()
+    .require_approval_for_dangerous(true)
+    .always_approve_tools(vec!["read_file"])  // Reading is safe
+    .always_deny_tools(vec!["delete_system_files"])  // Never allow
+    .timeout_seconds(60)
+    .build();
+
+// Build agent
+let agent = AgentBuilder::new()
+    .name("file-agent")
+    .backend(backend)
+    .tool(read_tool)
+    .tool(write_tool)
+    .tool(delete_tool)
+    .approval_handler(TerminalApprovalHandler::new(config))
+    .build();
+
+// Run - write and delete will prompt for approval
+agent.run("Organize my documents folder").await?;
+```
+
+## Error Handling
+
+```rust
+match approval_result {
+    Ok(ApprovalDecision::Approved) => {
+        // Execute tool
+    }
+    Ok(ApprovalDecision::Denied { reason }) => {
+        // Log denial, inform agent
+        agent.add_message(format!("Tool denied: {}", reason));
+    }
+    Ok(ApprovalDecision::Skip) => {
+        // Continue without this tool
+    }
+    Err(ApprovalError::Timeout(secs)) => {
+        // Handle timeout
+        log::warn!("Approval timed out after {}s", secs);
+    }
+    Err(ApprovalError::Denied(reason)) => {
+        // Handle explicit denial
+    }
+    Err(e) => {
+        // Handle other errors
+    }
+}
+```
+
+## Next Steps
+
+- [LLM Backends Guide](./backends.md) - Configure LLM providers
+- [MCP Integration](../crates/mcp/README.md) - Model Context Protocol

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -1,0 +1,387 @@
+# LLM Backends Guide
+
+This guide covers all LLM backend implementations in HyperAgent.
+
+## Overview
+
+HyperAgent supports multiple LLM providers through a unified `LLMBackend` trait:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      LLMBackend Trait                       │
+├─────────────────────────────────────────────────────────────┤
+│  infer()        - Single request inference                  │
+│  infer_stream() - Streaming inference with SSE              │
+│  embed()        - Text embeddings                           │
+│  model_info()   - Model metadata and pricing                │
+└─────────────────────────────────────────────────────────────┘
+          │              │              │              │
+          ▼              ▼              ▼              ▼
+    ┌──────────┐  ┌───────────┐  ┌────────────┐  ┌──────────┐
+    │  OpenAI  │  │ Anthropic │  │ OpenRouter │  │   Mock   │
+    │  GPT-4   │  │  Claude   │  │  200+ LLMs │  │  Testing │
+    └──────────┘  └───────────┘  └────────────┘  └──────────┘
+```
+
+## Quick Start
+
+```rust
+use rust_ai_agents_providers::{AnthropicProvider, OpenAIProvider, LLMBackend};
+
+// Anthropic Claude (recommended)
+let claude = AnthropicProvider::claude_35_sonnet(api_key);
+
+// OpenAI GPT-4
+let gpt4 = OpenAIProvider::new(api_key, "gpt-4-turbo".to_string());
+
+// Use with agent
+let agent = AgentBuilder::new()
+    .name("my-agent")
+    .backend(claude)
+    .build();
+```
+
+## Providers
+
+### Anthropic (Claude)
+
+Best for: Complex reasoning, long context, tool use, coding tasks.
+
+```rust
+use rust_ai_agents_providers::{AnthropicProvider, ClaudeModel};
+
+// Recommended: Claude 3.5 Sonnet - best balance of speed and intelligence
+let claude = AnthropicProvider::claude_35_sonnet(api_key);
+
+// High performance: Claude 3.5 Haiku - fast and efficient
+let haiku = AnthropicProvider::claude_35_haiku(api_key);
+
+// Maximum capability: Claude 3 Opus - most powerful
+let opus = AnthropicProvider::claude_3_opus(api_key);
+
+// Custom configuration
+let custom = AnthropicProvider::new(api_key, ClaudeModel::Claude35Sonnet)
+    .with_max_tokens(4096);
+```
+
+**Available Models:**
+
+| Model | Context | Input $/1M | Output $/1M | Best For |
+|-------|---------|------------|-------------|----------|
+| Claude 3.5 Sonnet | 200K | $3.00 | $15.00 | General use, coding |
+| Claude 3.5 Haiku | 200K | $1.00 | $5.00 | Fast tasks, high volume |
+| Claude 3 Opus | 200K | $15.00 | $75.00 | Complex reasoning |
+| Claude 3 Haiku | 200K | $0.25 | $1.25 | Simple tasks |
+
+**Features:**
+- Tool/function calling
+- Vision (image analysis)
+- Extended thinking
+- 200K token context window
+- Streaming support
+
+### OpenAI (GPT-4)
+
+Best for: General tasks, function calling, established ecosystem.
+
+```rust
+use rust_ai_agents_providers::OpenAIProvider;
+
+// GPT-4 Turbo (recommended)
+let gpt4 = OpenAIProvider::new(api_key, "gpt-4-turbo".to_string());
+
+// GPT-4o (multimodal)
+let gpt4o = OpenAIProvider::new(api_key, "gpt-4o".to_string());
+
+// GPT-3.5 Turbo (budget option)
+let gpt35 = OpenAIProvider::new(api_key, "gpt-3.5-turbo".to_string());
+
+// With custom rate limits
+let provider = OpenAIProvider::new(api_key, "gpt-4-turbo".to_string())
+    .with_rate_limits(500, 150_000); // RPM, TPM
+```
+
+**Available Models:**
+
+| Model | Context | Input $/1M | Output $/1M | Best For |
+|-------|---------|------------|-------------|----------|
+| gpt-4-turbo | 128K | $10.00 | $30.00 | Complex tasks |
+| gpt-4o | 128K | $5.00 | $15.00 | Multimodal |
+| gpt-4o-mini | 128K | $0.15 | $0.60 | Budget tasks |
+| gpt-3.5-turbo | 16K | $0.50 | $1.50 | Simple tasks |
+
+**Features:**
+- Tool/function calling
+- Vision (GPT-4o)
+- JSON mode
+- Streaming support
+
+### OpenRouter
+
+Best for: Access to 200+ models with a single API, model comparison.
+
+```rust
+use rust_ai_agents_providers::OpenRouterProvider;
+
+// Access any model
+let provider = OpenRouterProvider::new(api_key, "anthropic/claude-3.5-sonnet".to_string());
+
+// Llama models
+let llama = OpenRouterProvider::new(api_key, "meta-llama/llama-3.1-70b-instruct".to_string());
+
+// Mistral
+let mistral = OpenRouterProvider::new(api_key, "mistralai/mistral-large".to_string());
+```
+
+**Popular Models via OpenRouter:**
+
+| Model | Provider | Best For |
+|-------|----------|----------|
+| anthropic/claude-3.5-sonnet | Anthropic | General use |
+| openai/gpt-4-turbo | OpenAI | Complex tasks |
+| meta-llama/llama-3.1-70b | Meta | Open source |
+| mistralai/mistral-large | Mistral | European hosting |
+| google/gemini-pro-1.5 | Google | Long context |
+
+### MockBackend (Testing)
+
+Best for: Unit tests, integration tests, deterministic behavior.
+
+```rust
+use rust_ai_agents_providers::{MockBackend, MockResponse};
+use serde_json::json;
+
+// Simple text responses
+let backend = MockBackend::new()
+    .with_response(MockResponse::text("Hello, world!"));
+
+// Tool call responses
+let backend = MockBackend::new()
+    .with_response(MockResponse::tool_call("search", json!({"query": "rust"})));
+
+// Sequence of responses
+let backend = MockBackend::new()
+    .with_response(MockResponse::text("Let me search for that"))
+    .with_response(MockResponse::tool_call("search", json!({"q": "test"})))
+    .with_response(MockResponse::text("Here are the results"));
+
+// Pattern-based responses
+let backend = MockBackend::new()
+    .with_pattern_response(
+        MessageMatcher::Contains("weather".to_string()),
+        MockResponse::text("It's sunny today!")
+    );
+
+// Error simulation
+let backend = MockBackend::new()
+    .with_response(MockResponse::error("API rate limit exceeded"));
+
+// With simulated latency
+let backend = MockBackend::new()
+    .with_response(MockResponse::text("Slow response").with_latency(1000));
+
+// Echo mode (returns last user message)
+let backend = MockBackend::echo();
+```
+
+**Testing Example:**
+
+```rust
+#[tokio::test]
+async fn test_agent_tool_use() {
+    let backend = MockBackend::new()
+        .with_response(MockResponse::tool_call("calculator", json!({"expr": "2+2"})))
+        .with_response(MockResponse::text("The answer is 4"));
+
+    let agent = AgentBuilder::new()
+        .backend(backend.clone())
+        .tool(calculator_tool())
+        .build();
+
+    let result = agent.run("What is 2+2?").await.unwrap();
+    
+    // Verify calls were made
+    assert_eq!(backend.call_count(), 2);
+    assert!(backend.was_tool_called("calculator"));
+}
+```
+
+## LLMBackend Trait
+
+All providers implement the `LLMBackend` trait:
+
+```rust
+#[async_trait]
+pub trait LLMBackend: Send + Sync {
+    /// Perform inference
+    async fn infer(
+        &self,
+        messages: &[LLMMessage],
+        tools: &[ToolSchema],
+        temperature: f32,
+    ) -> Result<InferenceOutput, LLMError>;
+
+    /// Streaming inference
+    async fn infer_stream(
+        &self,
+        messages: &[LLMMessage],
+        tools: &[ToolSchema],
+        temperature: f32,
+    ) -> Result<StreamResponse, LLMError>;
+
+    /// Generate embeddings
+    async fn embed(&self, text: &str) -> Result<Vec<f32>, LLMError>;
+
+    /// Get model information
+    fn model_info(&self) -> ModelInfo;
+
+    /// Check capabilities
+    fn supports_function_calling(&self) -> bool;
+    fn supports_streaming(&self) -> bool;
+}
+```
+
+## Inference Output
+
+```rust
+pub struct InferenceOutput {
+    /// Generated text content
+    pub content: String,
+    
+    /// Tool calls (if any)
+    pub tool_calls: Option<Vec<ToolCall>>,
+    
+    /// Reasoning/chain-of-thought (if available)
+    pub reasoning: Option<String>,
+    
+    /// Model confidence (0.0 - 1.0)
+    pub confidence: f64,
+    
+    /// Token usage statistics
+    pub token_usage: TokenUsage,
+    
+    /// Additional metadata
+    pub metadata: HashMap<String, Value>,
+}
+
+pub struct TokenUsage {
+    pub prompt_tokens: usize,
+    pub completion_tokens: usize,
+    pub total_tokens: usize,
+    pub cached_tokens: Option<usize>,
+}
+```
+
+## Streaming
+
+Stream responses for real-time display:
+
+```rust
+use futures::StreamExt;
+
+let mut stream = backend.infer_stream(&messages, &tools, 0.7).await?;
+
+while let Some(event) = stream.next().await {
+    match event? {
+        StreamEvent::TextDelta(text) => print!("{}", text),
+        StreamEvent::ToolCallStart { id, name } => println!("Calling {}...", name),
+        StreamEvent::ToolCallDelta { id, arguments_delta } => { /* accumulate */ },
+        StreamEvent::ToolCallEnd { id } => println!("Tool call complete"),
+        StreamEvent::Done { token_usage } => println!("Done! Tokens: {:?}", token_usage),
+        StreamEvent::Error(e) => eprintln!("Error: {}", e),
+    }
+}
+```
+
+## Rate Limiting
+
+Built-in rate limiting prevents API throttling:
+
+```rust
+use rust_ai_agents_providers::{GovernorRateLimiter, RateLimitConfig};
+
+// Configure rate limits
+let config = RateLimitConfig::new()
+    .requests_per_minute(100)
+    .tokens_per_minute(100_000);
+
+let limiter = GovernorRateLimiter::new(config);
+
+// Provider with rate limiting
+let provider = AnthropicProvider::claude_35_sonnet(api_key)
+    .with_rate_limiter(limiter);
+```
+
+**Default Rate Limits by Provider:**
+
+| Provider | RPM | TPM |
+|----------|-----|-----|
+| Anthropic | 50 | 40,000 |
+| OpenAI (GPT-4) | 500 | 150,000 |
+| OpenRouter | Varies | Varies |
+
+## Retry Configuration
+
+Automatic retries for transient errors:
+
+```rust
+use rust_ai_agents_providers::{with_retry, RetryConfig};
+
+let config = RetryConfig::new()
+    .max_retries(3)
+    .initial_delay_ms(1000)
+    .max_delay_ms(30000)
+    .exponential_backoff(true);
+
+let result = with_retry(config, || async {
+    backend.infer(&messages, &tools, 0.7).await
+}).await?;
+```
+
+## Cost Tracking
+
+Track API costs:
+
+```rust
+let output = backend.infer(&messages, &tools, 0.7).await?;
+let model_info = backend.model_info();
+
+let cost = model_info.calculate_cost(&output.token_usage);
+println!("Request cost: ${:.4}", cost);
+```
+
+## Environment Variables
+
+Configure providers via environment:
+
+```bash
+# Anthropic
+export ANTHROPIC_API_KEY=sk-ant-...
+
+# OpenAI
+export OPENAI_API_KEY=sk-...
+
+# OpenRouter
+export OPENROUTER_API_KEY=sk-or-...
+```
+
+```rust
+let api_key = std::env::var("ANTHROPIC_API_KEY")?;
+let claude = AnthropicProvider::claude_35_sonnet(api_key);
+```
+
+## Choosing a Provider
+
+| Use Case | Recommended Provider |
+|----------|---------------------|
+| General agents | Anthropic Claude 3.5 Sonnet |
+| High volume | Anthropic Claude 3.5 Haiku |
+| Complex reasoning | Anthropic Claude 3 Opus |
+| Budget constraints | OpenAI GPT-4o-mini |
+| Model comparison | OpenRouter |
+| Testing | MockBackend |
+
+## Next Steps
+
+- [Approvals Guide](./approvals.md) - Human-in-the-loop approval system
+- [MCP Integration](../crates/mcp/README.md) - Model Context Protocol


### PR DESCRIPTION
## Summary

Adds comprehensive documentation for two key features.

## LLM Backends Guide (docs/backends.md) - Issue #6

- **LLMBackend trait** documentation and API reference
- **OpenAI provider**: GPT-4, GPT-4o, GPT-3.5 with examples
- **Anthropic provider**: Claude 3.5 Sonnet, Opus, Haiku with examples
- **OpenRouter provider**: 200+ models with unified API
- **MockBackend**: Deterministic testing with pattern matching
- **Streaming support**: SSE-based streaming examples
- **Rate limiting**: Configuration and defaults per provider
- **Cost tracking**: Token usage and pricing
- **Provider comparison table**: Context, pricing, best use cases

## Approvals Guide (docs/approvals.md) - Issue #7

- **Safety Sandwich architecture** pattern explained
- **ApprovalConfig builder** with all options
- **TerminalApprovalHandler**: Interactive CLI approval
- **TestApprovalHandler**: Automated testing support
- **AutoApproveHandler**: Bypass for trusted environments
- **Custom handlers**: Slack, webhook integration examples
- **Dangerous tools**: How to mark and configure
- **Best practices**: Defense in depth, least privilege, audit logging

## Additional Changes

- Fixed clippy warnings in `session_resources.rs`

Closes #6
Closes #7