### PR TITLE
feat(wasm): Browser WASM support with examples

### DIFF
--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -44,8 +44,8 @@ futures = { workspace = true }
 tracing = { workspace = true }
 tracing-wasm = "0.2"
 
-# UUID
-uuid = { workspace = true }
+# UUID (with js feature for WASM)
+uuid = { version = "1.8", features = ["v4", "serde", "js"] }
 
 # Getrandom for WASM
 getrandom = { version = "0.2", features = ["js"] }

--- a/crates/wasm/README.md
+++ b/crates/wasm/README.md
@@ -1,0 +1,201 @@
+# rust-ai-agents-wasm
+
+WebAssembly bindings for running AI agents directly in the browser.
+
+## Features
+
+- **Browser-native**: Run AI agents entirely in the browser with no server required
+- **Multiple Providers**: Support for OpenAI, Anthropic, and OpenRouter
+- **Streaming**: Real-time streaming responses
+- **TypeScript**: Full TypeScript type definitions included
+- **Lightweight**: Optimized WASM bundle
+
+## Installation
+
+```bash
+npm install rust-ai-agents-wasm
+# or
+yarn add rust-ai-agents-wasm
+# or
+pnpm add rust-ai-agents-wasm
+```
+
+## Quick Start
+
+### Vanilla JavaScript
+
+```javascript
+import init, { WasmAgent, WasmAgentConfig } from 'rust-ai-agents-wasm';
+
+// Initialize the WASM module
+await init();
+
+// Create an agent
+const config = new WasmAgentConfig('openai', 'sk-...', 'gpt-4o-mini');
+config.system_prompt = 'You are a helpful assistant.';
+config.temperature = 0.7;
+
+const agent = new WasmAgent(config);
+
+// Chat (non-streaming)
+const response = await agent.chat('Hello!');
+console.log(response.content);
+
+// Chat (streaming)
+const stream = await agent.chatStream('Tell me a story');
+const reader = stream.getReader();
+const decoder = new TextDecoder();
+
+while (true) {
+  const { done, value } = await reader.read();
+  if (done) break;
+  
+  const chunk = decoder.decode(value, { stream: true });
+  // Parse SSE data...
+}
+
+// Clear history
+agent.clear();
+
+// Free memory when done
+agent.free();
+```
+
+### React
+
+```tsx
+import { useWasmAgent } from 'rust-ai-agents-wasm/react';
+
+function Chat() {
+  const { sendMessageStream, messages, isStreaming, isReady } = useWasmAgent({
+    provider: 'openai',
+    apiKey: process.env.REACT_APP_OPENAI_API_KEY!,
+    model: 'gpt-4o-mini',
+    systemPrompt: 'You are a helpful assistant.',
+  });
+
+  return (
+    <div>
+      {messages.map((msg, i) => (
+        <div key={i} className={msg.role}>
+          {msg.content}
+        </div>
+      ))}
+      <button 
+        onClick={() => sendMessageStream('Hello!')}
+        disabled={!isReady || isStreaming}
+      >
+        Send
+      </button>
+    </div>
+  );
+}
+```
+
+## API Reference
+
+### WasmAgentConfig
+
+```typescript
+const config = new WasmAgentConfig(
+  provider: string,  // 'openai' | 'anthropic' | 'openrouter'
+  apiKey: string,
+  model: string
+);
+
+// Optional settings
+config.system_prompt = 'You are...';
+config.temperature = 0.7;      // 0.0 - 2.0
+config.max_tokens = 4096;
+```
+
+### WasmAgent
+
+```typescript
+const agent = new WasmAgent(config);
+
+// Non-streaming chat
+const response = await agent.chat(message: string);
+// Returns: { content: string, tool_calls?: [...], usage?: {...} }
+
+// Streaming chat
+const stream = await agent.chatStream(message: string);
+// Returns: ReadableStream
+
+// Get conversation history
+const history = agent.getHistory();
+// Returns: Array<{ role: string, content: string }>
+
+// Clear conversation
+agent.clear();
+
+// Free memory
+agent.free();
+```
+
+### WasmMessage
+
+```typescript
+const userMsg = WasmMessage.user('Hello');
+const assistantMsg = WasmMessage.assistant('Hi there!');
+
+console.log(userMsg.role);     // 'user'
+console.log(userMsg.content);  // 'Hello'
+```
+
+## Supported Providers
+
+| Provider | Models | Streaming | Notes |
+|----------|--------|-----------|-------|
+| OpenAI | gpt-4o, gpt-4o-mini, gpt-3.5-turbo, etc. | ✅ | |
+| Anthropic | claude-3-opus, claude-3-sonnet, etc. | ✅ | Requires `anthropic-dangerous-direct-browser-access` header |
+| OpenRouter | 100+ models | ✅ | Best for accessing multiple providers |
+
+## Security Considerations
+
+⚠️ **API Keys in Browser**: This library is designed for prototyping and demos. In production:
+
+1. **Never expose API keys** in client-side code
+2. Use a backend proxy to handle API calls
+3. Implement proper authentication and rate limiting
+
+For production use, consider:
+- Using OpenRouter with a limited-scope API key
+- Implementing a server-side proxy
+- Using Anthropic's `anthropic-dangerous-direct-browser-access` header only for demos
+
+## Browser Compatibility
+
+| Browser | Supported |
+|---------|-----------|
+| Chrome 89+ | ✅ |
+| Firefox 89+ | ✅ |
+| Safari 15+ | ✅ |
+| Edge 89+ | ✅ |
+
+Requires:
+- WebAssembly
+- Fetch API
+- ReadableStream
+- TextDecoder
+
+## Examples
+
+See the `/examples` directory for:
+- `browser/index.html` - Vanilla JavaScript demo
+- `react/` - React hook and component examples
+
+## Development
+
+```bash
+# Build WASM package
+cd crates/wasm
+wasm-pack build --target web --out-dir pkg
+
+# Run tests
+wasm-pack test --headless --firefox
+```
+
+## License
+
+Apache-2.0

--- a/crates/wasm/examples/browser/index.html
+++ b/crates/wasm/examples/browser/index.html
@@ -1,0 +1,300 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Rust AI Agents - Browser Demo</title>
+    <style>
+        * {
+            box-sizing: border-box;
+        }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            background: #1a1a2e;
+            color: #eee;
+        }
+        h1 {
+            color: #00d4ff;
+        }
+        .config {
+            background: #16213e;
+            padding: 20px;
+            border-radius: 8px;
+            margin-bottom: 20px;
+        }
+        .config label {
+            display: block;
+            margin-bottom: 5px;
+            color: #888;
+        }
+        .config input, .config select {
+            width: 100%;
+            padding: 10px;
+            margin-bottom: 15px;
+            border: 1px solid #333;
+            border-radius: 4px;
+            background: #0f0f23;
+            color: #eee;
+        }
+        .chat-container {
+            background: #16213e;
+            border-radius: 8px;
+            overflow: hidden;
+        }
+        .messages {
+            height: 400px;
+            overflow-y: auto;
+            padding: 20px;
+        }
+        .message {
+            margin-bottom: 15px;
+            padding: 12px 16px;
+            border-radius: 8px;
+            max-width: 80%;
+        }
+        .message.user {
+            background: #00d4ff;
+            color: #000;
+            margin-left: auto;
+        }
+        .message.assistant {
+            background: #2d2d44;
+        }
+        .message.system {
+            background: #3d1a1a;
+            color: #ff6b6b;
+            font-size: 0.9em;
+        }
+        .input-area {
+            display: flex;
+            padding: 15px;
+            background: #0f0f23;
+        }
+        .input-area input {
+            flex: 1;
+            padding: 12px;
+            border: none;
+            border-radius: 4px 0 0 4px;
+            background: #16213e;
+            color: #eee;
+        }
+        .input-area button {
+            padding: 12px 24px;
+            border: none;
+            border-radius: 0 4px 4px 0;
+            background: #00d4ff;
+            color: #000;
+            cursor: pointer;
+            font-weight: bold;
+        }
+        .input-area button:hover {
+            background: #00b8e6;
+        }
+        .input-area button:disabled {
+            background: #444;
+            cursor: not-allowed;
+        }
+        .status {
+            padding: 10px;
+            text-align: center;
+            font-size: 0.9em;
+            color: #888;
+        }
+        .streaming {
+            animation: pulse 1s infinite;
+        }
+        @keyframes pulse {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.5; }
+        }
+    </style>
+</head>
+<body>
+    <h1>Rust AI Agents - Browser Demo</h1>
+
+    <div class="config">
+        <label>Provider</label>
+        <select id="provider">
+            <option value="openai">OpenAI</option>
+            <option value="anthropic">Anthropic</option>
+            <option value="openrouter">OpenRouter</option>
+        </select>
+
+        <label>API Key</label>
+        <input type="password" id="apiKey" placeholder="Enter your API key">
+
+        <label>Model</label>
+        <input type="text" id="model" value="gpt-4o-mini" placeholder="Model name">
+
+        <label>System Prompt (optional)</label>
+        <input type="text" id="systemPrompt" placeholder="You are a helpful assistant...">
+    </div>
+
+    <div class="chat-container">
+        <div class="messages" id="messages">
+            <div class="message system">
+                Loading WASM module...
+            </div>
+        </div>
+        <div class="input-area">
+            <input type="text" id="userInput" placeholder="Type your message..." disabled>
+            <button id="sendBtn" disabled>Send</button>
+        </div>
+    </div>
+
+    <div class="status" id="status">Initializing...</div>
+
+    <script type="module">
+        import init, { WasmAgent, WasmAgentConfig } from '../pkg/rust_ai_agents_wasm.js';
+
+        let agent = null;
+        const messagesEl = document.getElementById('messages');
+        const userInputEl = document.getElementById('userInput');
+        const sendBtnEl = document.getElementById('sendBtn');
+        const statusEl = document.getElementById('status');
+
+        function addMessage(content, role) {
+            const div = document.createElement('div');
+            div.className = `message ${role}`;
+            div.textContent = content;
+            messagesEl.appendChild(div);
+            messagesEl.scrollTop = messagesEl.scrollHeight;
+            return div;
+        }
+
+        function clearMessages() {
+            messagesEl.innerHTML = '';
+        }
+
+        function updateStatus(text, isStreaming = false) {
+            statusEl.textContent = text;
+            statusEl.className = isStreaming ? 'status streaming' : 'status';
+        }
+
+        function createAgent() {
+            const provider = document.getElementById('provider').value;
+            const apiKey = document.getElementById('apiKey').value;
+            const model = document.getElementById('model').value;
+            const systemPrompt = document.getElementById('systemPrompt').value;
+
+            if (!apiKey) {
+                addMessage('Please enter an API key', 'system');
+                return false;
+            }
+
+            const config = new WasmAgentConfig(provider, apiKey, model);
+            if (systemPrompt) {
+                config.system_prompt = systemPrompt;
+            }
+            config.temperature = 0.7;
+            config.max_tokens = 2048;
+
+            agent = new WasmAgent(config);
+            clearMessages();
+            addMessage(`Agent created with ${provider}/${model}`, 'system');
+            return true;
+        }
+
+        async function sendMessage() {
+            const message = userInputEl.value.trim();
+            if (!message) return;
+
+            if (!agent && !createAgent()) return;
+
+            userInputEl.value = '';
+            userInputEl.disabled = true;
+            sendBtnEl.disabled = true;
+
+            addMessage(message, 'user');
+            const responseDiv = addMessage('', 'assistant');
+
+            try {
+                updateStatus('Sending request...', true);
+
+                // Use streaming
+                const stream = await agent.chatStream(message);
+                const reader = stream.getReader();
+                const decoder = new TextDecoder();
+                let fullResponse = '';
+
+                updateStatus('Receiving response...', true);
+
+                while (true) {
+                    const { done, value } = await reader.read();
+                    if (done) break;
+
+                    const chunk = decoder.decode(value, { stream: true });
+                    // Parse SSE data
+                    const lines = chunk.split('\n');
+                    for (const line of lines) {
+                        if (line.startsWith('data: ')) {
+                            const data = line.slice(6);
+                            if (data === '[DONE]') continue;
+                            try {
+                                const parsed = JSON.parse(data);
+                                const content = parsed.choices?.[0]?.delta?.content ||
+                                               parsed.delta?.text || '';
+                                if (content) {
+                                    fullResponse += content;
+                                    responseDiv.textContent = fullResponse;
+                                    messagesEl.scrollTop = messagesEl.scrollHeight;
+                                }
+                            } catch (e) {
+                                // Not JSON, might be raw text
+                            }
+                        }
+                    }
+                }
+
+                updateStatus('Ready');
+
+            } catch (error) {
+                responseDiv.textContent = `Error: ${error.message || error}`;
+                responseDiv.className = 'message system';
+                updateStatus('Error occurred');
+            }
+
+            userInputEl.disabled = false;
+            sendBtnEl.disabled = false;
+            userInputEl.focus();
+        }
+
+        // Initialize
+        async function main() {
+            try {
+                await init();
+                updateStatus('WASM loaded. Enter your API key to start.');
+                clearMessages();
+                addMessage('WASM module loaded successfully! Enter your API key and start chatting.', 'system');
+
+                userInputEl.disabled = false;
+                sendBtnEl.disabled = false;
+
+                sendBtnEl.addEventListener('click', sendMessage);
+                userInputEl.addEventListener('keypress', (e) => {
+                    if (e.key === 'Enter') sendMessage();
+                });
+
+                // Recreate agent when config changes
+                ['provider', 'model', 'systemPrompt'].forEach(id => {
+                    document.getElementById(id).addEventListener('change', () => {
+                        if (agent) {
+                            agent.free();
+                            agent = null;
+                        }
+                    });
+                });
+
+            } catch (error) {
+                updateStatus('Failed to load WASM');
+                addMessage(`Failed to initialize: ${error.message}`, 'system');
+            }
+        }
+
+        main();
+    </script>
+</body>
+</html>

--- a/crates/wasm/examples/react/ChatComponent.tsx
+++ b/crates/wasm/examples/react/ChatComponent.tsx
@@ -1,0 +1,251 @@
+/**
+ * Example React component using the Rust AI Agents WASM module.
+ *
+ * @example
+ * ```tsx
+ * import { ChatComponent } from './ChatComponent';
+ *
+ * function App() {
+ *   return (
+ *     <ChatComponent
+ *       provider="openai"
+ *       apiKey={process.env.REACT_APP_OPENAI_API_KEY!}
+ *       model="gpt-4o-mini"
+ *     />
+ *   );
+ * }
+ * ```
+ */
+
+import React, { useState, useRef, useEffect } from 'react';
+import { useWasmAgent } from './useWasmAgent';
+
+interface ChatComponentProps {
+  provider: 'openai' | 'anthropic' | 'openrouter';
+  apiKey: string;
+  model: string;
+  systemPrompt?: string;
+  className?: string;
+}
+
+export function ChatComponent({
+  provider,
+  apiKey,
+  model,
+  systemPrompt,
+  className = '',
+}: ChatComponentProps) {
+  const [input, setInput] = useState('');
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  const {
+    sendMessageStream,
+    messages,
+    isStreaming,
+    error,
+    clearHistory,
+    isReady,
+  } = useWasmAgent({
+    provider,
+    apiKey,
+    model,
+    systemPrompt,
+    temperature: 0.7,
+    maxTokens: 2048,
+  });
+
+  // Auto-scroll to bottom
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!input.trim() || isStreaming) return;
+
+    const message = input.trim();
+    setInput('');
+    await sendMessageStream(message);
+  };
+
+  return (
+    <div className={`chat-component ${className}`} style={styles.container}>
+      <div style={styles.header}>
+        <h3 style={styles.title}>AI Chat</h3>
+        <span style={styles.status}>
+          {!isReady ? '🔄 Loading...' : isStreaming ? '💭 Thinking...' : '✅ Ready'}
+        </span>
+        <button onClick={clearHistory} style={styles.clearBtn}>
+          Clear
+        </button>
+      </div>
+
+      <div style={styles.messages}>
+        {messages.length === 0 && (
+          <div style={styles.emptyState}>
+            Start a conversation...
+          </div>
+        )}
+
+        {messages.map((msg, index) => (
+          <div
+            key={index}
+            style={{
+              ...styles.message,
+              ...(msg.role === 'user' ? styles.userMessage : {}),
+              ...(msg.role === 'assistant' ? styles.assistantMessage : {}),
+              ...(msg.role === 'system' ? styles.systemMessage : {}),
+            }}
+          >
+            <div style={styles.messageRole}>
+              {msg.role === 'user' ? '👤 You' : msg.role === 'assistant' ? '🤖 AI' : '⚠️ System'}
+            </div>
+            <div style={styles.messageContent}>
+              {msg.content || (isStreaming && index === messages.length - 1 ? '...' : '')}
+            </div>
+          </div>
+        ))}
+
+        <div ref={messagesEndRef} />
+      </div>
+
+      {error && (
+        <div style={styles.error}>
+          Error: {error.message}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} style={styles.inputArea}>
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder={isReady ? "Type your message..." : "Loading..."}
+          disabled={!isReady || isStreaming}
+          style={styles.input}
+        />
+        <button
+          type="submit"
+          disabled={!isReady || isStreaming || !input.trim()}
+          style={styles.sendBtn}
+        >
+          {isStreaming ? '...' : 'Send'}
+        </button>
+      </form>
+    </div>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    height: '500px',
+    maxWidth: '600px',
+    border: '1px solid #333',
+    borderRadius: '8px',
+    overflow: 'hidden',
+    backgroundColor: '#1a1a2e',
+    color: '#eee',
+    fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+  },
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    padding: '12px 16px',
+    backgroundColor: '#16213e',
+    borderBottom: '1px solid #333',
+  },
+  title: {
+    margin: 0,
+    fontSize: '16px',
+    fontWeight: 600,
+    flex: 1,
+  },
+  status: {
+    fontSize: '12px',
+    color: '#888',
+    marginRight: '12px',
+  },
+  clearBtn: {
+    padding: '4px 12px',
+    fontSize: '12px',
+    border: '1px solid #444',
+    borderRadius: '4px',
+    backgroundColor: 'transparent',
+    color: '#888',
+    cursor: 'pointer',
+  },
+  messages: {
+    flex: 1,
+    overflowY: 'auto',
+    padding: '16px',
+  },
+  emptyState: {
+    textAlign: 'center',
+    color: '#666',
+    padding: '40px',
+  },
+  message: {
+    marginBottom: '12px',
+    padding: '12px',
+    borderRadius: '8px',
+    maxWidth: '85%',
+  },
+  userMessage: {
+    backgroundColor: '#00d4ff',
+    color: '#000',
+    marginLeft: 'auto',
+  },
+  assistantMessage: {
+    backgroundColor: '#2d2d44',
+  },
+  systemMessage: {
+    backgroundColor: '#3d1a1a',
+    color: '#ff6b6b',
+    fontSize: '13px',
+  },
+  messageRole: {
+    fontSize: '11px',
+    fontWeight: 600,
+    marginBottom: '4px',
+    opacity: 0.7,
+  },
+  messageContent: {
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-word',
+  },
+  error: {
+    padding: '8px 16px',
+    backgroundColor: '#3d1a1a',
+    color: '#ff6b6b',
+    fontSize: '13px',
+  },
+  inputArea: {
+    display: 'flex',
+    padding: '12px',
+    backgroundColor: '#0f0f23',
+    borderTop: '1px solid #333',
+  },
+  input: {
+    flex: 1,
+    padding: '10px 14px',
+    border: 'none',
+    borderRadius: '4px 0 0 4px',
+    backgroundColor: '#16213e',
+    color: '#eee',
+    fontSize: '14px',
+    outline: 'none',
+  },
+  sendBtn: {
+    padding: '10px 20px',
+    border: 'none',
+    borderRadius: '0 4px 4px 0',
+    backgroundColor: '#00d4ff',
+    color: '#000',
+    fontWeight: 600,
+    cursor: 'pointer',
+  },
+};
+
+export default ChatComponent;

--- a/crates/wasm/examples/react/useWasmAgent.ts
+++ b/crates/wasm/examples/react/useWasmAgent.ts
@@ -1,0 +1,285 @@
+/**
+ * React hook for using Rust AI Agents in the browser.
+ *
+ * @example
+ * ```tsx
+ * import { useWasmAgent } from './useWasmAgent';
+ *
+ * function ChatComponent() {
+ *   const { sendMessage, messages, isLoading, error } = useWasmAgent({
+ *     provider: 'openai',
+ *     apiKey: process.env.OPENAI_API_KEY!,
+ *     model: 'gpt-4o-mini',
+ *     systemPrompt: 'You are a helpful assistant.',
+ *   });
+ *
+ *   return (
+ *     <div>
+ *       {messages.map((msg, i) => (
+ *         <div key={i} className={msg.role}>
+ *           {msg.content}
+ *         </div>
+ *       ))}
+ *       <button onClick={() => sendMessage('Hello!')}>
+ *         Send
+ *       </button>
+ *     </div>
+ *   );
+ * }
+ * ```
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+
+// Types for the WASM module
+interface WasmAgentConfig {
+  provider: string;
+  apiKey: string;
+  model: string;
+  systemPrompt?: string;
+  temperature?: number;
+  maxTokens?: number;
+}
+
+interface Message {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+}
+
+interface UseWasmAgentOptions extends WasmAgentConfig {
+  onError?: (error: Error) => void;
+  onMessage?: (message: Message) => void;
+}
+
+interface UseWasmAgentReturn {
+  sendMessage: (content: string) => Promise<void>;
+  sendMessageStream: (content: string) => Promise<void>;
+  messages: Message[];
+  isLoading: boolean;
+  isStreaming: boolean;
+  error: Error | null;
+  clearHistory: () => void;
+  isReady: boolean;
+}
+
+// Dynamic import of WASM module
+let wasmModule: any = null;
+let wasmInitPromise: Promise<any> | null = null;
+
+async function loadWasm() {
+  if (wasmModule) return wasmModule;
+  if (wasmInitPromise) return wasmInitPromise;
+
+  wasmInitPromise = (async () => {
+    // Adjust path based on your setup
+    const wasm = await import('rust-ai-agents-wasm');
+    await wasm.default();
+    wasmModule = wasm;
+    return wasm;
+  })();
+
+  return wasmInitPromise;
+}
+
+export function useWasmAgent(options: UseWasmAgentOptions): UseWasmAgentReturn {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [isReady, setIsReady] = useState(false);
+
+  const agentRef = useRef<any>(null);
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  // Initialize WASM and create agent
+  useEffect(() => {
+    let mounted = true;
+
+    async function init() {
+      try {
+        const wasm = await loadWasm();
+
+        if (!mounted) return;
+
+        const { WasmAgent, WasmAgentConfig } = wasm;
+
+        const config = new WasmAgentConfig(
+          options.provider,
+          options.apiKey,
+          options.model
+        );
+
+        if (options.systemPrompt) {
+          config.system_prompt = options.systemPrompt;
+        }
+        if (options.temperature !== undefined) {
+          config.temperature = options.temperature;
+        }
+        if (options.maxTokens !== undefined) {
+          config.max_tokens = options.maxTokens;
+        }
+
+        agentRef.current = new WasmAgent(config);
+        setIsReady(true);
+        setError(null);
+
+      } catch (err) {
+        if (mounted) {
+          const error = err instanceof Error ? err : new Error(String(err));
+          setError(error);
+          options.onError?.(error);
+        }
+      }
+    }
+
+    init();
+
+    return () => {
+      mounted = false;
+      if (agentRef.current) {
+        agentRef.current.free();
+        agentRef.current = null;
+      }
+    };
+  }, [options.provider, options.apiKey, options.model]);
+
+  // Send message (non-streaming)
+  const sendMessage = useCallback(async (content: string) => {
+    if (!agentRef.current || isLoading) return;
+
+    const userMessage: Message = { role: 'user', content };
+    setMessages(prev => [...prev, userMessage]);
+    optionsRef.current.onMessage?.(userMessage);
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await agentRef.current.chat(content);
+      const assistantMessage: Message = {
+        role: 'assistant',
+        content: response.content
+      };
+      setMessages(prev => [...prev, assistantMessage]);
+      optionsRef.current.onMessage?.(assistantMessage);
+
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      optionsRef.current.onError?.(error);
+
+      const errorMessage: Message = {
+        role: 'system',
+        content: `Error: ${error.message}`
+      };
+      setMessages(prev => [...prev, errorMessage]);
+
+    } finally {
+      setIsLoading(false);
+    }
+  }, [isLoading]);
+
+  // Send message (streaming)
+  const sendMessageStream = useCallback(async (content: string) => {
+    if (!agentRef.current || isStreaming) return;
+
+    const userMessage: Message = { role: 'user', content };
+    setMessages(prev => [...prev, userMessage]);
+    optionsRef.current.onMessage?.(userMessage);
+
+    setIsStreaming(true);
+    setError(null);
+
+    // Add placeholder for assistant response
+    let fullResponse = '';
+    setMessages(prev => [...prev, { role: 'assistant', content: '' }]);
+
+    try {
+      const stream = await agentRef.current.chatStream(content);
+      const reader = stream.getReader();
+      const decoder = new TextDecoder();
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        const chunk = decoder.decode(value, { stream: true });
+
+        // Parse SSE data
+        const lines = chunk.split('\n');
+        for (const line of lines) {
+          if (line.startsWith('data: ')) {
+            const data = line.slice(6);
+            if (data === '[DONE]') continue;
+
+            try {
+              const parsed = JSON.parse(data);
+              const text = parsed.choices?.[0]?.delta?.content ||
+                          parsed.delta?.text || '';
+
+              if (text) {
+                fullResponse += text;
+                setMessages(prev => {
+                  const updated = [...prev];
+                  updated[updated.length - 1] = {
+                    role: 'assistant',
+                    content: fullResponse
+                  };
+                  return updated;
+                });
+              }
+            } catch {
+              // Not JSON
+            }
+          }
+        }
+      }
+
+      const assistantMessage: Message = {
+        role: 'assistant',
+        content: fullResponse
+      };
+      optionsRef.current.onMessage?.(assistantMessage);
+
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      optionsRef.current.onError?.(error);
+
+      setMessages(prev => {
+        const updated = [...prev];
+        updated[updated.length - 1] = {
+          role: 'system',
+          content: `Error: ${error.message}`
+        };
+        return updated;
+      });
+
+    } finally {
+      setIsStreaming(false);
+    }
+  }, [isStreaming]);
+
+  // Clear history
+  const clearHistory = useCallback(() => {
+    if (agentRef.current) {
+      agentRef.current.clear();
+    }
+    setMessages([]);
+    setError(null);
+  }, []);
+
+  return {
+    sendMessage,
+    sendMessageStream,
+    messages,
+    isLoading,
+    isStreaming,
+    error,
+    clearHistory,
+    isReady,
+  };
+}
+
+export default useWasmAgent;


### PR DESCRIPTION
## Summary
Implements Issue #13 - Browser WASM Support (Linear: RML-10)

## Changes

### WASM Fixes
- Fixed `uuid` dependency for WASM target (added `js` feature)
- Package builds successfully with `wasm-pack build --target web`

### Browser Examples
- **`examples/browser/index.html`**: Interactive vanilla JS demo with:
  - Provider selection (OpenAI, Anthropic, OpenRouter)
  - Model configuration
  - Streaming chat interface
  - Dark theme UI

### React Integration
- **`useWasmAgent.ts`**: React hook with:
  - Automatic WASM initialization
  - Streaming and non-streaming chat
  - Error handling
  - Conversation history management
  - TypeScript types

- **`ChatComponent.tsx`**: Ready-to-use component with:
  - Full chat UI
  - Auto-scroll
  - Loading states
  - Styled with inline CSS

### Documentation
- Comprehensive README with:
  - Installation instructions
  - API reference
  - Code examples
  - Security considerations
  - Browser compatibility

## Testing
- WASM builds successfully: `wasm-pack build --target web --dev`
- Clippy passes
- TypeScript definitions generated

## Usage Example

```tsx
import { useWasmAgent } from 'rust-ai-agents-wasm/react';

function Chat() {
  const { sendMessageStream, messages, isReady } = useWasmAgent({
    provider: 'openai',
    apiKey: 'sk-...',
    model: 'gpt-4o-mini',
  });

  return <button onClick={() => sendMessageStream('Hello!')}>Send</button>;
}
```

Closes #13