### PR TITLE
feat: add llm-client and fastly crates for multi-runtime support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ members = [
     "crates/cache",
     "crates/audit",
     "crates/github-ops",
+    "crates/llm-client",
+    "crates/fastly",
     "examples",
 ]
 

--- a/crates/fastly/Cargo.toml
+++ b/crates/fastly/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "rust-ai-agents-fastly"
+version = "0.1.0"
+edition = "2021"
+description = "Fastly Compute runtime for rust-ai-agents"
+license = "Apache-2.0"
+authors = ["Ronaldo Lima"]
+repository = "https://github.com/limaronaldo/rust-ai-agents"
+keywords = ["ai", "agents", "llm", "fastly", "edge"]
+categories = ["api-bindings", "wasm"]
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+# Shared LLM client logic
+rust-ai-agents-llm-client = { path = "../llm-client" }
+
+# Fastly SDK
+fastly = "0.10"
+
+# Serialization
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+# Error handling
+thiserror = "1.0"
+
+[dev-dependencies]
+# Note: Fastly Compute testing requires the Fastly CLI

--- a/crates/fastly/src/lib.rs
+++ b/crates/fastly/src/lib.rs
@@ -1,0 +1,397 @@
+//! # Rust AI Agents - Fastly Compute
+//!
+//! Run AI agents on Fastly Compute@Edge.
+//!
+//! This crate provides a Fastly-native implementation using:
+//! - `rust-ai-agents-llm-client` for request/response logic
+//! - Fastly SDK for HTTP requests
+//!
+//! ## Usage
+//!
+//! ```rust,ignore
+//! use rust_ai_agents_fastly::{FastlyAgent, FastlyAgentConfig};
+//! use fastly::{Request, Response};
+//!
+//! #[fastly::main]
+//! fn main(req: Request) -> Result<Response, fastly::Error> {
+//!     let config = FastlyAgentConfig::new(
+//!         "openai",
+//!         std::env::var("OPENAI_API_KEY").unwrap(),
+//!         "gpt-4o-mini",
+//!     );
+//!
+//!     let mut agent = FastlyAgent::new(config, "llm-backend");
+//!     let response = agent.chat("Hello!")?;
+//!
+//!     Ok(Response::from_body(response.content))
+//! }
+//! ```
+
+use std::io::Read;
+
+use fastly::http::{header, Method, StatusCode};
+use fastly::{Backend, Body, Request, Response};
+use rust_ai_agents_llm_client::{
+    LlmResponse, Message, Provider, RequestBuilder, ResponseParser, StreamChunk,
+};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Errors that can occur in the Fastly agent
+#[derive(Debug, Error)]
+pub enum FastlyAgentError {
+    #[error("LLM client error: {0}")]
+    LlmClient(#[from] rust_ai_agents_llm_client::LlmClientError),
+
+    #[error("Fastly error: {0}")]
+    Fastly(String),
+
+    #[error("HTTP error: {status} - {message}")]
+    Http { status: u16, message: String },
+
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("Invalid provider: {0}")]
+    InvalidProvider(String),
+}
+
+impl From<fastly::Error> for FastlyAgentError {
+    fn from(e: fastly::Error) -> Self {
+        FastlyAgentError::Fastly(e.to_string())
+    }
+}
+
+impl From<fastly::http::request::SendError> for FastlyAgentError {
+    fn from(e: fastly::http::request::SendError) -> Self {
+        FastlyAgentError::Fastly(format!("Send error: {:?}", e))
+    }
+}
+
+pub type Result<T> = std::result::Result<T, FastlyAgentError>;
+
+/// Configuration for the Fastly agent
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FastlyAgentConfig {
+    /// LLM provider
+    pub provider: String,
+    /// API key
+    pub api_key: String,
+    /// Model identifier
+    pub model: String,
+    /// System prompt
+    pub system_prompt: Option<String>,
+    /// Temperature (0.0 - 2.0)
+    pub temperature: f32,
+    /// Maximum tokens to generate
+    pub max_tokens: u32,
+}
+
+impl FastlyAgentConfig {
+    /// Create a new configuration
+    pub fn new(
+        provider: impl Into<String>,
+        api_key: impl Into<String>,
+        model: impl Into<String>,
+    ) -> Self {
+        Self {
+            provider: provider.into(),
+            api_key: api_key.into(),
+            model: model.into(),
+            system_prompt: None,
+            temperature: 0.7,
+            max_tokens: 4096,
+        }
+    }
+
+    /// Set system prompt
+    pub fn with_system_prompt(mut self, prompt: impl Into<String>) -> Self {
+        self.system_prompt = Some(prompt.into());
+        self
+    }
+
+    /// Set temperature
+    pub fn with_temperature(mut self, temp: f32) -> Self {
+        self.temperature = temp.clamp(0.0, 2.0);
+        self
+    }
+
+    /// Set max tokens
+    pub fn with_max_tokens(mut self, tokens: u32) -> Self {
+        self.max_tokens = tokens;
+        self
+    }
+}
+
+/// AI Agent for Fastly Compute
+pub struct FastlyAgent {
+    config: FastlyAgentConfig,
+    backend_name: String,
+    messages: Vec<Message>,
+    provider: Provider,
+}
+
+impl FastlyAgent {
+    /// Create a new Fastly agent
+    ///
+    /// # Arguments
+    /// * `config` - Agent configuration
+    /// * `backend_name` - Name of the Fastly backend configured for LLM API
+    pub fn new(config: FastlyAgentConfig, backend_name: impl Into<String>) -> Result<Self> {
+        let provider = config
+            .provider
+            .parse::<Provider>()
+            .map_err(|_| FastlyAgentError::InvalidProvider(config.provider.clone()))?;
+
+        Ok(Self {
+            config,
+            backend_name: backend_name.into(),
+            messages: Vec::new(),
+            provider,
+        })
+    }
+
+    /// Send a message and get a response
+    pub fn chat(&mut self, message: &str) -> Result<LlmResponse> {
+        // Add user message
+        self.messages.push(Message::user(message));
+
+        // Build request using llm-client
+        let mut builder = RequestBuilder::new(self.provider)
+            .model(&self.config.model)
+            .api_key(&self.config.api_key)
+            .temperature(self.config.temperature)
+            .max_tokens(self.config.max_tokens)
+            .stream(false);
+
+        // Add system prompt if present
+        if let Some(ref system) = self.config.system_prompt {
+            builder = builder.add_message(Message::system(system));
+        }
+
+        // Add conversation messages
+        builder = builder.messages(&self.messages);
+
+        let http_request = builder.build()?;
+
+        // Create Fastly request
+        let mut req = Request::new(Method::POST, &http_request.url);
+
+        for (key, value) in &http_request.headers {
+            req.set_header(key, value);
+        }
+
+        req.set_body(http_request.body);
+
+        // Send request via Fastly backend
+        let backend = Backend::from_name(&self.backend_name)
+            .map_err(|e| FastlyAgentError::Fastly(format!("Backend not found: {}", e)))?;
+
+        let resp = req.send(backend)?;
+
+        // Check status
+        if resp.get_status() != StatusCode::OK {
+            let status = resp.get_status().as_u16();
+            let body = resp.into_body_str();
+            return Err(FastlyAgentError::Http {
+                status,
+                message: body,
+            });
+        }
+
+        // Parse response using llm-client
+        let body = resp.into_body_str();
+        let response = ResponseParser::parse(self.provider, &body)?;
+
+        // Add assistant message to history
+        self.messages.push(Message::assistant(&response.content));
+
+        Ok(response)
+    }
+
+    /// Send a message and get a streaming response
+    ///
+    /// Returns an iterator over stream chunks
+    pub fn chat_stream(&mut self, message: &str) -> Result<StreamingResponse> {
+        // Add user message
+        self.messages.push(Message::user(message));
+
+        // Build request using llm-client
+        let mut builder = RequestBuilder::new(self.provider)
+            .model(&self.config.model)
+            .api_key(&self.config.api_key)
+            .temperature(self.config.temperature)
+            .max_tokens(self.config.max_tokens)
+            .stream(true);
+
+        // Add system prompt if present
+        if let Some(ref system) = self.config.system_prompt {
+            builder = builder.add_message(Message::system(system));
+        }
+
+        // Add conversation messages
+        builder = builder.messages(&self.messages);
+
+        let http_request = builder.build()?;
+
+        // Create Fastly request
+        let mut req = Request::new(Method::POST, &http_request.url);
+
+        for (key, value) in &http_request.headers {
+            req.set_header(key, value);
+        }
+
+        req.set_body(http_request.body);
+
+        // Send request via Fastly backend
+        let backend = Backend::from_name(&self.backend_name)
+            .map_err(|e| FastlyAgentError::Fastly(format!("Backend not found: {}", e)))?;
+
+        let resp = req.send(backend)?;
+
+        // Check status
+        if resp.get_status() != StatusCode::OK {
+            let status = resp.get_status().as_u16();
+            let body = resp.into_body_str();
+            return Err(FastlyAgentError::Http {
+                status,
+                message: body,
+            });
+        }
+
+        Ok(StreamingResponse {
+            body: resp.into_body(),
+            provider: self.provider,
+            buffer: String::new(),
+            accumulated_content: String::new(),
+        })
+    }
+
+    /// Clear conversation history
+    pub fn clear(&mut self) {
+        self.messages.clear();
+    }
+
+    /// Get conversation history
+    pub fn history(&self) -> &[Message] {
+        &self.messages
+    }
+
+    /// Add assistant response to history (for streaming)
+    pub fn add_assistant_message(&mut self, content: impl Into<String>) {
+        self.messages.push(Message::assistant(content));
+    }
+}
+
+/// Streaming response iterator
+pub struct StreamingResponse {
+    body: Body,
+    provider: Provider,
+    buffer: String,
+    accumulated_content: String,
+}
+
+impl StreamingResponse {
+    /// Get the full accumulated content after streaming completes
+    pub fn content(&self) -> &str {
+        &self.accumulated_content
+    }
+
+    /// Process the next chunk from the stream
+    pub fn next_chunk(&mut self) -> Result<Option<StreamChunk>> {
+        // Read more data into buffer
+        let mut chunk_buf = [0u8; 1024];
+        let bytes_read = self
+            .body
+            .read(&mut chunk_buf)
+            .map_err(|e| FastlyAgentError::Fastly(e.to_string()))?;
+
+        if bytes_read == 0 {
+            return Ok(None);
+        }
+
+        // Add to buffer
+        let chunk_str = String::from_utf8_lossy(&chunk_buf[..bytes_read]);
+        self.buffer.push_str(&chunk_str);
+
+        // Process complete lines
+        while let Some(line_end) = self.buffer.find('\n') {
+            let line = self.buffer[..line_end].to_string();
+            self.buffer = self.buffer[line_end + 1..].to_string();
+
+            if let Ok(Some(chunk)) = ResponseParser::parse_stream_line(self.provider, &line) {
+                if let Some(ref content) = chunk.content {
+                    self.accumulated_content.push_str(content);
+                }
+                return Ok(Some(chunk));
+            }
+        }
+
+        // No complete chunk yet, keep reading
+        self.next_chunk()
+    }
+}
+
+impl std::io::Read for StreamingResponse {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.body.read(buf)
+    }
+}
+
+/// Create a simple chat completion handler for Fastly
+///
+/// This is a convenience function for simple use cases.
+pub fn handle_chat_request(
+    incoming_req: Request,
+    config: FastlyAgentConfig,
+    backend_name: &str,
+) -> Result<Response> {
+    // Parse incoming request
+    let body: serde_json::Value = serde_json::from_str(&incoming_req.into_body_str())?;
+
+    let message = body["message"]
+        .as_str()
+        .ok_or_else(|| FastlyAgentError::Fastly("Missing 'message' field".to_string()))?;
+
+    // Create agent and chat
+    let mut agent = FastlyAgent::new(config, backend_name)?;
+    let response = agent.chat(message)?;
+
+    // Build response
+    let response_body = serde_json::json!({
+        "content": response.content,
+        "usage": response.usage,
+    });
+
+    let mut resp = Response::from_body(response_body.to_string());
+    resp.set_header(header::CONTENT_TYPE, "application/json");
+
+    Ok(resp)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_config_creation() {
+        let config = FastlyAgentConfig::new("openai", "sk-test", "gpt-4o-mini")
+            .with_system_prompt("You are helpful")
+            .with_temperature(0.5)
+            .with_max_tokens(2048);
+
+        assert_eq!(config.provider, "openai");
+        assert_eq!(config.model, "gpt-4o-mini");
+        assert_eq!(config.system_prompt, Some("You are helpful".to_string()));
+        assert_eq!(config.temperature, 0.5);
+        assert_eq!(config.max_tokens, 2048);
+    }
+
+    #[test]
+    fn test_provider_parsing() {
+        assert!("openai".parse::<Provider>().is_ok());
+        assert!("anthropic".parse::<Provider>().is_ok());
+        assert!("openrouter".parse::<Provider>().is_ok());
+        assert!("invalid".parse::<Provider>().is_err());
+    }
+}

--- a/crates/llm-client/Cargo.toml
+++ b/crates/llm-client/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "rust-ai-agents-llm-client"
+version = "0.1.0"
+edition = "2021"
+description = "Shared LLM client logic for multiple runtimes (browser, edge, server)"
+license = "Apache-2.0"
+repository = "https://github.com/limaronaldo/rust-ai-agents"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "1.0"
+
+[dev-dependencies]
+pretty_assertions = "1.4"

--- a/crates/llm-client/src/error.rs
+++ b/crates/llm-client/src/error.rs
@@ -1,0 +1,62 @@
+//! Error types for the LLM client.
+
+use thiserror::Error;
+
+/// Result type for LLM client operations.
+pub type Result<T> = std::result::Result<T, LlmClientError>;
+
+/// Errors that can occur in the LLM client.
+#[derive(Debug, Error)]
+pub enum LlmClientError {
+    /// JSON serialization error
+    #[error("Serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+
+    /// Missing required field
+    #[error("Missing required field: {0}")]
+    MissingField(String),
+
+    /// Invalid provider
+    #[error("Unknown provider: {0}")]
+    UnknownProvider(String),
+
+    /// API error response
+    #[error("API error: {message} (type: {error_type})")]
+    ApiError {
+        error_type: String,
+        message: String,
+        code: Option<String>,
+    },
+
+    /// Unexpected response format
+    #[error("Unexpected response format: {0}")]
+    UnexpectedFormat(String),
+
+    /// Rate limit exceeded
+    #[error("Rate limit exceeded")]
+    RateLimited,
+
+    /// Authentication error
+    #[error("Authentication failed: {0}")]
+    AuthError(String),
+}
+
+impl LlmClientError {
+    /// Create a missing field error.
+    pub fn missing(field: &str) -> Self {
+        Self::MissingField(field.to_string())
+    }
+
+    /// Create an API error from response JSON.
+    pub fn from_api_response(json: &serde_json::Value) -> Self {
+        let error = &json["error"];
+        Self::ApiError {
+            error_type: error["type"].as_str().unwrap_or("unknown").to_string(),
+            message: error["message"]
+                .as_str()
+                .unwrap_or("Unknown error")
+                .to_string(),
+            code: error["code"].as_str().map(String::from),
+        }
+    }
+}

--- a/crates/llm-client/src/lib.rs
+++ b/crates/llm-client/src/lib.rs
@@ -1,0 +1,53 @@
+//! # LLM Client - Shared Logic
+//!
+//! Runtime-agnostic LLM client logic for building requests and parsing responses.
+//! This crate has NO runtime dependencies (no async, no HTTP client).
+//!
+//! ## Supported Providers
+//!
+//! - OpenAI (GPT-4, GPT-3.5, etc.)
+//! - Anthropic (Claude 3, etc.)
+//! - OpenRouter (100+ models)
+//!
+//! ## Usage
+//!
+//! ```rust
+//! use rust_ai_agents_llm_client::{
+//!     Provider, Message, RequestBuilder, ResponseParser,
+//! };
+//!
+//! // Build a request
+//! let messages = vec![
+//!     Message::system("You are a helpful assistant."),
+//!     Message::user("Hello!"),
+//! ];
+//!
+//! let request = RequestBuilder::new(Provider::OpenAI)
+//!     .model("gpt-4o-mini")
+//!     .messages(&messages)
+//!     .api_key("sk-...")
+//!     .temperature(0.7)
+//!     .max_tokens(1024)
+//!     .stream(false)
+//!     .build()
+//!     .unwrap();
+//!
+//! // Use your runtime's HTTP client to send request.url, request.headers, request.body
+//! // Then parse the response:
+//!
+//! let response_json = r#"{"choices":[{"message":{"content":"Hello!"}}]}"#;
+//! let response = ResponseParser::parse(Provider::OpenAI, response_json).unwrap();
+//! println!("{}", response.content);
+//! ```
+
+mod error;
+mod message;
+mod provider;
+mod request;
+mod response;
+
+pub use error::{LlmClientError, Result};
+pub use message::{Message, Role};
+pub use provider::Provider;
+pub use request::{HttpRequest, RequestBuilder};
+pub use response::{LlmResponse, ResponseParser, StreamChunk, ToolCall, ToolCallChunk, Usage};

--- a/crates/llm-client/src/message.rs
+++ b/crates/llm-client/src/message.rs
@@ -1,0 +1,103 @@
+//! Message types for conversations.
+
+use serde::{Deserialize, Serialize};
+
+/// Role in a conversation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Role {
+    /// System message (instructions)
+    System,
+    /// User message
+    User,
+    /// Assistant message
+    Assistant,
+    /// Tool/function result
+    Tool,
+}
+
+impl Role {
+    /// Convert to string for API requests.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::System => "system",
+            Self::User => "user",
+            Self::Assistant => "assistant",
+            Self::Tool => "tool",
+        }
+    }
+}
+
+/// A message in a conversation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Message {
+    /// Role of the message sender
+    pub role: Role,
+    /// Content of the message
+    pub content: String,
+    /// Tool call ID (for tool responses)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+}
+
+impl Message {
+    /// Create a new message.
+    pub fn new(role: Role, content: impl Into<String>) -> Self {
+        Self {
+            role,
+            content: content.into(),
+            tool_call_id: None,
+        }
+    }
+
+    /// Create a system message.
+    pub fn system(content: impl Into<String>) -> Self {
+        Self::new(Role::System, content)
+    }
+
+    /// Create a user message.
+    pub fn user(content: impl Into<String>) -> Self {
+        Self::new(Role::User, content)
+    }
+
+    /// Create an assistant message.
+    pub fn assistant(content: impl Into<String>) -> Self {
+        Self::new(Role::Assistant, content)
+    }
+
+    /// Create a tool result message.
+    pub fn tool(tool_call_id: impl Into<String>, content: impl Into<String>) -> Self {
+        Self {
+            role: Role::Tool,
+            content: content.into(),
+            tool_call_id: Some(tool_call_id.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_message_creation() {
+        let msg = Message::user("Hello");
+        assert_eq!(msg.role, Role::User);
+        assert_eq!(msg.content, "Hello");
+    }
+
+    #[test]
+    fn test_message_serialization() {
+        let msg = Message::system("You are helpful");
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains("system"));
+        assert!(json.contains("You are helpful"));
+    }
+
+    #[test]
+    fn test_tool_message() {
+        let msg = Message::tool("call_123", r#"{"result": "success"}"#);
+        assert_eq!(msg.role, Role::Tool);
+        assert_eq!(msg.tool_call_id, Some("call_123".to_string()));
+    }
+}

--- a/crates/llm-client/src/provider.rs
+++ b/crates/llm-client/src/provider.rs
@@ -1,0 +1,111 @@
+//! LLM Provider definitions.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Supported LLM providers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Provider {
+    /// OpenAI (GPT-4, GPT-3.5, etc.)
+    OpenAI,
+    /// Anthropic (Claude 3, etc.)
+    Anthropic,
+    /// OpenRouter (100+ models)
+    OpenRouter,
+}
+
+impl Provider {
+    /// Get the API endpoint URL for this provider.
+    pub fn endpoint(&self) -> &'static str {
+        match self {
+            Self::OpenAI => "https://api.openai.com/v1/chat/completions",
+            Self::Anthropic => "https://api.anthropic.com/v1/messages",
+            Self::OpenRouter => "https://openrouter.ai/api/v1/chat/completions",
+        }
+    }
+
+    /// Get the header name for the API key.
+    pub fn auth_header(&self) -> &'static str {
+        match self {
+            Self::OpenAI | Self::OpenRouter => "Authorization",
+            Self::Anthropic => "x-api-key",
+        }
+    }
+
+    /// Format the API key for the authorization header.
+    pub fn format_auth(&self, api_key: &str) -> String {
+        match self {
+            Self::OpenAI | Self::OpenRouter => format!("Bearer {}", api_key),
+            Self::Anthropic => api_key.to_string(),
+        }
+    }
+
+    /// Get additional required headers for this provider.
+    pub fn extra_headers(&self) -> Vec<(&'static str, &'static str)> {
+        match self {
+            Self::OpenAI => vec![],
+            Self::Anthropic => vec![
+                ("anthropic-version", "2023-06-01"),
+                ("anthropic-dangerous-direct-browser-access", "true"),
+            ],
+            Self::OpenRouter => vec![("HTTP-Referer", "https://rust-ai-agents.dev")],
+        }
+    }
+
+    /// Check if this provider uses OpenAI-compatible format.
+    pub fn is_openai_compatible(&self) -> bool {
+        matches!(self, Self::OpenAI | Self::OpenRouter)
+    }
+}
+
+impl fmt::Display for Provider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::OpenAI => write!(f, "openai"),
+            Self::Anthropic => write!(f, "anthropic"),
+            Self::OpenRouter => write!(f, "openrouter"),
+        }
+    }
+}
+
+impl std::str::FromStr for Provider {
+    type Err = crate::LlmClientError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "openai" => Ok(Self::OpenAI),
+            "anthropic" => Ok(Self::Anthropic),
+            "openrouter" => Ok(Self::OpenRouter),
+            _ => Err(crate::LlmClientError::UnknownProvider(s.to_string())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_provider_endpoints() {
+        assert!(Provider::OpenAI.endpoint().contains("openai.com"));
+        assert!(Provider::Anthropic.endpoint().contains("anthropic.com"));
+        assert!(Provider::OpenRouter.endpoint().contains("openrouter.ai"));
+    }
+
+    #[test]
+    fn test_provider_from_str() {
+        assert_eq!("openai".parse::<Provider>().unwrap(), Provider::OpenAI);
+        assert_eq!(
+            "ANTHROPIC".parse::<Provider>().unwrap(),
+            Provider::Anthropic
+        );
+        assert!("invalid".parse::<Provider>().is_err());
+    }
+
+    #[test]
+    fn test_auth_format() {
+        assert!(Provider::OpenAI.format_auth("key").starts_with("Bearer "));
+        assert_eq!(Provider::Anthropic.format_auth("key"), "key");
+    }
+}

--- a/crates/llm-client/src/request.rs
+++ b/crates/llm-client/src/request.rs
@@ -1,0 +1,345 @@
+//! Request building for LLM APIs.
+
+use crate::{LlmClientError, Message, Provider, Result};
+use serde::Serialize;
+
+/// An HTTP request ready to be sent.
+///
+/// This struct contains all the information needed to make an HTTP request,
+/// but does NOT include any HTTP client implementation.
+#[derive(Debug, Clone)]
+pub struct HttpRequest {
+    /// HTTP method (always POST for LLM APIs)
+    pub method: &'static str,
+    /// Full URL
+    pub url: String,
+    /// Headers as key-value pairs
+    pub headers: Vec<(String, String)>,
+    /// JSON body as string
+    pub body: String,
+}
+
+/// Builder for constructing LLM API requests.
+#[derive(Debug, Clone)]
+pub struct RequestBuilder {
+    provider: Provider,
+    model: Option<String>,
+    messages: Vec<Message>,
+    api_key: Option<String>,
+    temperature: Option<f32>,
+    max_tokens: Option<u32>,
+    stream: bool,
+    top_p: Option<f32>,
+    stop: Option<Vec<String>>,
+}
+
+impl RequestBuilder {
+    /// Create a new request builder for the given provider.
+    pub fn new(provider: Provider) -> Self {
+        Self {
+            provider,
+            model: None,
+            messages: Vec::new(),
+            api_key: None,
+            temperature: None,
+            max_tokens: None,
+            stream: false,
+            top_p: None,
+            stop: None,
+        }
+    }
+
+    /// Set the model to use.
+    pub fn model(mut self, model: impl Into<String>) -> Self {
+        self.model = Some(model.into());
+        self
+    }
+
+    /// Set the messages for the conversation.
+    pub fn messages(mut self, messages: &[Message]) -> Self {
+        self.messages = messages.to_vec();
+        self
+    }
+
+    /// Add a single message to the conversation.
+    pub fn add_message(mut self, message: Message) -> Self {
+        self.messages.push(message);
+        self
+    }
+
+    /// Set the API key.
+    pub fn api_key(mut self, key: impl Into<String>) -> Self {
+        self.api_key = Some(key.into());
+        self
+    }
+
+    /// Set the temperature (0.0 - 2.0).
+    pub fn temperature(mut self, temp: f32) -> Self {
+        self.temperature = Some(temp.clamp(0.0, 2.0));
+        self
+    }
+
+    /// Set the maximum tokens to generate.
+    pub fn max_tokens(mut self, tokens: u32) -> Self {
+        self.max_tokens = Some(tokens);
+        self
+    }
+
+    /// Enable or disable streaming.
+    pub fn stream(mut self, enable: bool) -> Self {
+        self.stream = enable;
+        self
+    }
+
+    /// Set top_p (nucleus sampling).
+    pub fn top_p(mut self, p: f32) -> Self {
+        self.top_p = Some(p.clamp(0.0, 1.0));
+        self
+    }
+
+    /// Set stop sequences.
+    pub fn stop(mut self, sequences: Vec<String>) -> Self {
+        self.stop = Some(sequences);
+        self
+    }
+
+    /// Build the HTTP request.
+    pub fn build(&self) -> Result<HttpRequest> {
+        let model = self
+            .model
+            .as_ref()
+            .ok_or_else(|| LlmClientError::missing("model"))?;
+        let api_key = self
+            .api_key
+            .as_ref()
+            .ok_or_else(|| LlmClientError::missing("api_key"))?;
+
+        if self.messages.is_empty() {
+            return Err(LlmClientError::missing("messages"));
+        }
+
+        let url = self.provider.endpoint().to_string();
+        let headers = self.build_headers(api_key);
+        let body = self.build_body(model)?;
+
+        Ok(HttpRequest {
+            method: "POST",
+            url,
+            headers,
+            body,
+        })
+    }
+
+    fn build_headers(&self, api_key: &str) -> Vec<(String, String)> {
+        let mut headers = vec![
+            ("Content-Type".to_string(), "application/json".to_string()),
+            (
+                self.provider.auth_header().to_string(),
+                self.provider.format_auth(api_key),
+            ),
+        ];
+
+        for (key, value) in self.provider.extra_headers() {
+            headers.push((key.to_string(), value.to_string()));
+        }
+
+        headers
+    }
+
+    fn build_body(&self, model: &str) -> Result<String> {
+        match self.provider {
+            Provider::OpenAI | Provider::OpenRouter => self.build_openai_body(model),
+            Provider::Anthropic => self.build_anthropic_body(model),
+        }
+    }
+
+    fn build_openai_body(&self, model: &str) -> Result<String> {
+        #[derive(Serialize)]
+        struct OpenAIRequest<'a> {
+            model: &'a str,
+            messages: &'a [OpenAIMessage<'a>],
+            #[serde(skip_serializing_if = "Option::is_none")]
+            temperature: Option<f32>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            max_tokens: Option<u32>,
+            stream: bool,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            top_p: Option<f32>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            stop: Option<&'a [String]>,
+        }
+
+        #[derive(Serialize)]
+        struct OpenAIMessage<'a> {
+            role: &'a str,
+            content: &'a str,
+        }
+
+        let messages: Vec<OpenAIMessage> = self
+            .messages
+            .iter()
+            .map(|m| OpenAIMessage {
+                role: m.role.as_str(),
+                content: &m.content,
+            })
+            .collect();
+
+        let request = OpenAIRequest {
+            model,
+            messages: &messages,
+            temperature: self.temperature,
+            max_tokens: self.max_tokens,
+            stream: self.stream,
+            top_p: self.top_p,
+            stop: self.stop.as_deref(),
+        };
+
+        Ok(serde_json::to_string(&request)?)
+    }
+
+    fn build_anthropic_body(&self, model: &str) -> Result<String> {
+        #[derive(Serialize)]
+        struct AnthropicRequest<'a> {
+            model: &'a str,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            system: Option<&'a str>,
+            messages: Vec<AnthropicMessage<'a>>,
+            max_tokens: u32,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            temperature: Option<f32>,
+            stream: bool,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            top_p: Option<f32>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            stop_sequences: Option<&'a [String]>,
+        }
+
+        #[derive(Serialize)]
+        struct AnthropicMessage<'a> {
+            role: &'a str,
+            content: &'a str,
+        }
+
+        // Extract system message (Anthropic handles it separately)
+        let system = self
+            .messages
+            .iter()
+            .find(|m| m.role == crate::Role::System)
+            .map(|m| m.content.as_str());
+
+        // Filter out system messages for the messages array
+        let messages: Vec<AnthropicMessage> = self
+            .messages
+            .iter()
+            .filter(|m| m.role != crate::Role::System)
+            .map(|m| AnthropicMessage {
+                role: if m.role == crate::Role::User {
+                    "user"
+                } else {
+                    "assistant"
+                },
+                content: &m.content,
+            })
+            .collect();
+
+        let request = AnthropicRequest {
+            model,
+            system,
+            messages,
+            max_tokens: self.max_tokens.unwrap_or(4096),
+            temperature: self.temperature,
+            stream: self.stream,
+            top_p: self.top_p,
+            stop_sequences: self.stop.as_deref(),
+        };
+
+        Ok(serde_json::to_string(&request)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_openai_request() {
+        let request = RequestBuilder::new(Provider::OpenAI)
+            .model("gpt-4o-mini")
+            .api_key("sk-test")
+            .add_message(Message::system("You are helpful"))
+            .add_message(Message::user("Hello"))
+            .temperature(0.7)
+            .max_tokens(1024)
+            .build()
+            .unwrap();
+
+        assert_eq!(request.method, "POST");
+        assert!(request.url.contains("openai.com"));
+        assert!(request.body.contains("gpt-4o-mini"));
+        assert!(request.body.contains("Hello"));
+
+        // Check headers
+        let auth_header = request.headers.iter().find(|(k, _)| k == "Authorization");
+        assert!(auth_header.is_some());
+        assert!(auth_header.unwrap().1.starts_with("Bearer "));
+    }
+
+    #[test]
+    fn test_anthropic_request() {
+        let request = RequestBuilder::new(Provider::Anthropic)
+            .model("claude-3-sonnet-20240229")
+            .api_key("sk-ant-test")
+            .add_message(Message::system("You are helpful"))
+            .add_message(Message::user("Hello"))
+            .max_tokens(1024)
+            .build()
+            .unwrap();
+
+        assert!(request.url.contains("anthropic.com"));
+        assert!(request.body.contains("claude-3"));
+        // Anthropic puts system message separately
+        assert!(request.body.contains(r#""system":"You are helpful"#));
+
+        // Check anthropic-version header
+        let version_header = request
+            .headers
+            .iter()
+            .find(|(k, _)| k == "anthropic-version");
+        assert!(version_header.is_some());
+    }
+
+    #[test]
+    fn test_missing_model() {
+        let result = RequestBuilder::new(Provider::OpenAI)
+            .api_key("sk-test")
+            .add_message(Message::user("Hello"))
+            .build();
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("model"));
+    }
+
+    #[test]
+    fn test_missing_messages() {
+        let result = RequestBuilder::new(Provider::OpenAI)
+            .model("gpt-4")
+            .api_key("sk-test")
+            .build();
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("messages"));
+    }
+
+    #[test]
+    fn test_streaming() {
+        let request = RequestBuilder::new(Provider::OpenAI)
+            .model("gpt-4")
+            .api_key("sk-test")
+            .add_message(Message::user("Hello"))
+            .stream(true)
+            .build()
+            .unwrap();
+
+        assert!(request.body.contains(r#""stream":true"#));
+    }
+}

--- a/crates/llm-client/src/response.rs
+++ b/crates/llm-client/src/response.rs
@@ -1,0 +1,615 @@
+//! Response parsing for LLM API responses
+//!
+//! This module provides runtime-agnostic parsing of responses from
+//! OpenAI, Anthropic, and OpenRouter APIs.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{LlmClientError, Result};
+use crate::provider::Provider;
+
+/// Parsed LLM response
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LlmResponse {
+    /// The generated text content
+    pub content: String,
+    /// Token usage information (if available)
+    pub usage: Option<Usage>,
+    /// Tool calls requested by the model (if any)
+    pub tool_calls: Vec<ToolCall>,
+    /// The finish reason
+    pub finish_reason: Option<String>,
+    /// Model used for generation
+    pub model: Option<String>,
+}
+
+/// Token usage information
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Usage {
+    /// Number of tokens in the prompt
+    pub prompt_tokens: u32,
+    /// Number of tokens in the completion
+    pub completion_tokens: u32,
+    /// Total tokens used
+    pub total_tokens: u32,
+}
+
+/// Tool call requested by the model
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolCall {
+    /// Unique identifier for this tool call
+    pub id: String,
+    /// Name of the function to call
+    pub function_name: String,
+    /// JSON arguments for the function
+    pub arguments: String,
+}
+
+/// Streaming chunk from SSE response
+#[derive(Debug, Clone)]
+pub struct StreamChunk {
+    /// Content delta (partial text)
+    pub content: Option<String>,
+    /// Whether this is the final chunk
+    pub done: bool,
+    /// Finish reason (on final chunk)
+    pub finish_reason: Option<String>,
+    /// Tool call chunks (for streaming tool calls)
+    pub tool_call_chunk: Option<ToolCallChunk>,
+}
+
+/// Partial tool call information from streaming
+#[derive(Debug, Clone)]
+pub struct ToolCallChunk {
+    /// Index of the tool call (for ordering)
+    pub index: usize,
+    /// Tool call ID (first chunk only)
+    pub id: Option<String>,
+    /// Function name (first chunk only)
+    pub function_name: Option<String>,
+    /// Arguments delta
+    pub arguments_delta: Option<String>,
+}
+
+/// Response parser for different providers
+pub struct ResponseParser;
+
+impl ResponseParser {
+    /// Parse a complete (non-streaming) response
+    pub fn parse(provider: Provider, body: &str) -> Result<LlmResponse> {
+        match provider {
+            Provider::OpenAI | Provider::OpenRouter => Self::parse_openai(body),
+            Provider::Anthropic => Self::parse_anthropic(body),
+        }
+    }
+
+    /// Parse a streaming SSE line
+    pub fn parse_stream_line(provider: Provider, line: &str) -> Result<Option<StreamChunk>> {
+        // Skip empty lines and comments
+        let line = line.trim();
+        if line.is_empty() || line.starts_with(':') {
+            return Ok(None);
+        }
+
+        // Extract data from SSE format
+        let data = if let Some(stripped) = line.strip_prefix("data: ") {
+            stripped.trim()
+        } else {
+            return Ok(None);
+        };
+
+        // Check for stream end
+        if data == "[DONE]" {
+            return Ok(Some(StreamChunk {
+                content: None,
+                done: true,
+                finish_reason: None,
+                tool_call_chunk: None,
+            }));
+        }
+
+        match provider {
+            Provider::OpenAI | Provider::OpenRouter => Self::parse_openai_stream_chunk(data),
+            Provider::Anthropic => Self::parse_anthropic_stream_chunk(data),
+        }
+    }
+
+    fn parse_openai(body: &str) -> Result<LlmResponse> {
+        let json: serde_json::Value = serde_json::from_str(body)
+            .map_err(|e| LlmClientError::UnexpectedFormat(e.to_string()))?;
+
+        // Check for error response
+        if json.get("error").is_some() {
+            return Err(LlmClientError::from_api_response(&json));
+        }
+
+        let choices = json
+            .get("choices")
+            .and_then(|c| c.as_array())
+            .ok_or_else(|| {
+                LlmClientError::UnexpectedFormat("Missing 'choices' field".to_string())
+            })?;
+
+        let first_choice = choices
+            .first()
+            .ok_or_else(|| LlmClientError::UnexpectedFormat("Empty choices array".to_string()))?;
+
+        let message = first_choice.get("message").ok_or_else(|| {
+            LlmClientError::UnexpectedFormat("Missing 'message' field".to_string())
+        })?;
+
+        let content = message
+            .get("content")
+            .and_then(|c| c.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        let finish_reason = first_choice
+            .get("finish_reason")
+            .and_then(|f| f.as_str())
+            .map(|s| s.to_string());
+
+        let model = json
+            .get("model")
+            .and_then(|m| m.as_str())
+            .map(|s| s.to_string());
+
+        // Parse tool calls if present
+        let tool_calls = Self::parse_openai_tool_calls(message);
+
+        // Parse usage
+        let usage = json.get("usage").and_then(|u| {
+            Some(Usage {
+                prompt_tokens: u.get("prompt_tokens")?.as_u64()? as u32,
+                completion_tokens: u.get("completion_tokens")?.as_u64()? as u32,
+                total_tokens: u.get("total_tokens")?.as_u64()? as u32,
+            })
+        });
+
+        Ok(LlmResponse {
+            content,
+            usage,
+            tool_calls,
+            finish_reason,
+            model,
+        })
+    }
+
+    fn parse_openai_tool_calls(message: &serde_json::Value) -> Vec<ToolCall> {
+        let Some(tool_calls) = message.get("tool_calls").and_then(|t| t.as_array()) else {
+            return Vec::new();
+        };
+
+        tool_calls
+            .iter()
+            .filter_map(|tc| {
+                let id = tc.get("id")?.as_str()?.to_string();
+                let function = tc.get("function")?;
+                let function_name = function.get("name")?.as_str()?.to_string();
+                let arguments = function.get("arguments")?.as_str()?.to_string();
+                Some(ToolCall {
+                    id,
+                    function_name,
+                    arguments,
+                })
+            })
+            .collect()
+    }
+
+    fn parse_anthropic(body: &str) -> Result<LlmResponse> {
+        let json: serde_json::Value = serde_json::from_str(body)
+            .map_err(|e| LlmClientError::UnexpectedFormat(e.to_string()))?;
+
+        // Check for error response
+        if json.get("error").is_some() {
+            return Err(LlmClientError::from_api_response(&json));
+        }
+
+        // Anthropic returns content as an array of blocks
+        let content_blocks = json
+            .get("content")
+            .and_then(|c| c.as_array())
+            .ok_or_else(|| {
+                LlmClientError::UnexpectedFormat("Missing 'content' field".to_string())
+            })?;
+
+        let mut content = String::new();
+        let mut tool_calls = Vec::new();
+
+        for block in content_blocks {
+            let block_type = block.get("type").and_then(|t| t.as_str()).unwrap_or("");
+
+            match block_type {
+                "text" => {
+                    if let Some(text) = block.get("text").and_then(|t| t.as_str()) {
+                        if !content.is_empty() {
+                            content.push('\n');
+                        }
+                        content.push_str(text);
+                    }
+                }
+                "tool_use" => {
+                    if let (Some(id), Some(name), Some(input)) = (
+                        block.get("id").and_then(|i| i.as_str()),
+                        block.get("name").and_then(|n| n.as_str()),
+                        block.get("input"),
+                    ) {
+                        tool_calls.push(ToolCall {
+                            id: id.to_string(),
+                            function_name: name.to_string(),
+                            arguments: serde_json::to_string(input).unwrap_or_default(),
+                        });
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let finish_reason = json
+            .get("stop_reason")
+            .and_then(|s| s.as_str())
+            .map(|s| s.to_string());
+
+        let model = json
+            .get("model")
+            .and_then(|m| m.as_str())
+            .map(|s| s.to_string());
+
+        let usage = json.get("usage").and_then(|u| {
+            Some(Usage {
+                prompt_tokens: u.get("input_tokens")?.as_u64()? as u32,
+                completion_tokens: u.get("output_tokens")?.as_u64()? as u32,
+                total_tokens: (u.get("input_tokens")?.as_u64()?
+                    + u.get("output_tokens")?.as_u64()?) as u32,
+            })
+        });
+
+        Ok(LlmResponse {
+            content,
+            usage,
+            tool_calls,
+            finish_reason,
+            model,
+        })
+    }
+
+    fn parse_openai_stream_chunk(data: &str) -> Result<Option<StreamChunk>> {
+        let json: serde_json::Value = serde_json::from_str(data)
+            .map_err(|e| LlmClientError::UnexpectedFormat(e.to_string()))?;
+
+        let choices = json.get("choices").and_then(|c| c.as_array());
+        let Some(choices) = choices else {
+            return Ok(None);
+        };
+
+        let Some(first_choice) = choices.first() else {
+            return Ok(None);
+        };
+
+        let finish_reason = first_choice.get("finish_reason").and_then(|f| {
+            if f.is_null() {
+                None
+            } else {
+                f.as_str().map(|s| s.to_string())
+            }
+        });
+
+        let delta = first_choice.get("delta");
+
+        let content = delta
+            .and_then(|d| d.get("content"))
+            .and_then(|c| c.as_str())
+            .map(|s| s.to_string());
+
+        // Parse streaming tool calls
+        let tool_call_chunk = delta
+            .and_then(|d| d.get("tool_calls"))
+            .and_then(|t| t.as_array())
+            .and_then(|arr| arr.first())
+            .and_then(|tc| {
+                let index = tc.get("index")?.as_u64()? as usize;
+                let id = tc.get("id").and_then(|i| i.as_str()).map(|s| s.to_string());
+                let function = tc.get("function");
+                let function_name = function
+                    .and_then(|f| f.get("name"))
+                    .and_then(|n| n.as_str())
+                    .map(|s| s.to_string());
+                let arguments_delta = function
+                    .and_then(|f| f.get("arguments"))
+                    .and_then(|a| a.as_str())
+                    .map(|s| s.to_string());
+
+                Some(ToolCallChunk {
+                    index,
+                    id,
+                    function_name,
+                    arguments_delta,
+                })
+            });
+
+        let done = finish_reason.is_some();
+
+        Ok(Some(StreamChunk {
+            content,
+            done,
+            finish_reason,
+            tool_call_chunk,
+        }))
+    }
+
+    fn parse_anthropic_stream_chunk(data: &str) -> Result<Option<StreamChunk>> {
+        let json: serde_json::Value = serde_json::from_str(data)
+            .map_err(|e| LlmClientError::UnexpectedFormat(e.to_string()))?;
+
+        let event_type = json.get("type").and_then(|t| t.as_str()).unwrap_or("");
+
+        match event_type {
+            "content_block_delta" => {
+                let delta = json.get("delta");
+                let delta_type = delta
+                    .and_then(|d| d.get("type"))
+                    .and_then(|t| t.as_str())
+                    .unwrap_or("");
+
+                match delta_type {
+                    "text_delta" => {
+                        let content = delta
+                            .and_then(|d| d.get("text"))
+                            .and_then(|t| t.as_str())
+                            .map(|s| s.to_string());
+
+                        Ok(Some(StreamChunk {
+                            content,
+                            done: false,
+                            finish_reason: None,
+                            tool_call_chunk: None,
+                        }))
+                    }
+                    "input_json_delta" => {
+                        let partial_json = delta
+                            .and_then(|d| d.get("partial_json"))
+                            .and_then(|p| p.as_str())
+                            .map(|s| s.to_string());
+
+                        let index =
+                            json.get("index").and_then(|i| i.as_u64()).unwrap_or(0) as usize;
+
+                        Ok(Some(StreamChunk {
+                            content: None,
+                            done: false,
+                            finish_reason: None,
+                            tool_call_chunk: Some(ToolCallChunk {
+                                index,
+                                id: None,
+                                function_name: None,
+                                arguments_delta: partial_json,
+                            }),
+                        }))
+                    }
+                    _ => Ok(None),
+                }
+            }
+            "content_block_start" => {
+                let content_block = json.get("content_block");
+                let block_type = content_block
+                    .and_then(|b| b.get("type"))
+                    .and_then(|t| t.as_str())
+                    .unwrap_or("");
+
+                if block_type == "tool_use" {
+                    let id = content_block
+                        .and_then(|b| b.get("id"))
+                        .and_then(|i| i.as_str())
+                        .map(|s| s.to_string());
+                    let name = content_block
+                        .and_then(|b| b.get("name"))
+                        .and_then(|n| n.as_str())
+                        .map(|s| s.to_string());
+                    let index = json.get("index").and_then(|i| i.as_u64()).unwrap_or(0) as usize;
+
+                    Ok(Some(StreamChunk {
+                        content: None,
+                        done: false,
+                        finish_reason: None,
+                        tool_call_chunk: Some(ToolCallChunk {
+                            index,
+                            id,
+                            function_name: name,
+                            arguments_delta: None,
+                        }),
+                    }))
+                } else {
+                    Ok(None)
+                }
+            }
+            "message_delta" => {
+                let stop_reason = json
+                    .get("delta")
+                    .and_then(|d| d.get("stop_reason"))
+                    .and_then(|s| s.as_str())
+                    .map(|s| s.to_string());
+
+                Ok(Some(StreamChunk {
+                    content: None,
+                    done: stop_reason.is_some(),
+                    finish_reason: stop_reason,
+                    tool_call_chunk: None,
+                }))
+            }
+            "message_stop" => Ok(Some(StreamChunk {
+                content: None,
+                done: true,
+                finish_reason: Some("end_turn".to_string()),
+                tool_call_chunk: None,
+            })),
+            _ => Ok(None),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_openai_response() {
+        let body = r#"{
+            "id": "chatcmpl-123",
+            "object": "chat.completion",
+            "model": "gpt-4",
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "Hello, world!"
+                },
+                "finish_reason": "stop"
+            }],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15
+            }
+        }"#;
+
+        let response = ResponseParser::parse(Provider::OpenAI, body).unwrap();
+        assert_eq!(response.content, "Hello, world!");
+        assert_eq!(response.finish_reason, Some("stop".to_string()));
+        assert_eq!(response.model, Some("gpt-4".to_string()));
+        assert!(response.tool_calls.is_empty());
+
+        let usage = response.usage.unwrap();
+        assert_eq!(usage.prompt_tokens, 10);
+        assert_eq!(usage.completion_tokens, 5);
+        assert_eq!(usage.total_tokens, 15);
+    }
+
+    #[test]
+    fn test_parse_openai_with_tool_calls() {
+        let body = r#"{
+            "id": "chatcmpl-123",
+            "model": "gpt-4",
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": "{\"location\": \"Paris\"}"
+                        }
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }]
+        }"#;
+
+        let response = ResponseParser::parse(Provider::OpenAI, body).unwrap();
+        assert_eq!(response.tool_calls.len(), 1);
+        assert_eq!(response.tool_calls[0].id, "call_123");
+        assert_eq!(response.tool_calls[0].function_name, "get_weather");
+        assert_eq!(
+            response.tool_calls[0].arguments,
+            "{\"location\": \"Paris\"}"
+        );
+    }
+
+    #[test]
+    fn test_parse_anthropic_response() {
+        let body = r#"{
+            "id": "msg_123",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-3-opus-20240229",
+            "content": [{
+                "type": "text",
+                "text": "Hello from Claude!"
+            }],
+            "stop_reason": "end_turn",
+            "usage": {
+                "input_tokens": 10,
+                "output_tokens": 5
+            }
+        }"#;
+
+        let response = ResponseParser::parse(Provider::Anthropic, body).unwrap();
+        assert_eq!(response.content, "Hello from Claude!");
+        assert_eq!(response.finish_reason, Some("end_turn".to_string()));
+        assert_eq!(response.model, Some("claude-3-opus-20240229".to_string()));
+
+        let usage = response.usage.unwrap();
+        assert_eq!(usage.prompt_tokens, 10);
+        assert_eq!(usage.completion_tokens, 5);
+        assert_eq!(usage.total_tokens, 15);
+    }
+
+    #[test]
+    fn test_parse_anthropic_with_tool_use() {
+        let body = r#"{
+            "id": "msg_123",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-3-opus-20240229",
+            "content": [{
+                "type": "tool_use",
+                "id": "toolu_123",
+                "name": "get_weather",
+                "input": {"location": "Paris"}
+            }],
+            "stop_reason": "tool_use"
+        }"#;
+
+        let response = ResponseParser::parse(Provider::Anthropic, body).unwrap();
+        assert_eq!(response.tool_calls.len(), 1);
+        assert_eq!(response.tool_calls[0].id, "toolu_123");
+        assert_eq!(response.tool_calls[0].function_name, "get_weather");
+    }
+
+    #[test]
+    fn test_parse_openai_stream_chunk() {
+        let data = r#"{"id":"chatcmpl-123","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}"#;
+
+        let chunk = ResponseParser::parse_stream_line(Provider::OpenAI, &format!("data: {}", data))
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(chunk.content, Some("Hello".to_string()));
+        assert!(!chunk.done);
+        assert!(chunk.finish_reason.is_none());
+    }
+
+    #[test]
+    fn test_parse_stream_done() {
+        let chunk = ResponseParser::parse_stream_line(Provider::OpenAI, "data: [DONE]")
+            .unwrap()
+            .unwrap();
+
+        assert!(chunk.done);
+        assert!(chunk.content.is_none());
+    }
+
+    #[test]
+    fn test_parse_anthropic_stream_text_delta() {
+        let data = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#;
+
+        let chunk =
+            ResponseParser::parse_stream_line(Provider::Anthropic, &format!("data: {}", data))
+                .unwrap()
+                .unwrap();
+
+        assert_eq!(chunk.content, Some("Hello".to_string()));
+        assert!(!chunk.done);
+    }
+
+    #[test]
+    fn test_parse_error_response() {
+        let body = r#"{"error": {"message": "Invalid API key", "type": "invalid_request_error"}}"#;
+
+        let result = ResponseParser::parse(Provider::OpenAI, body);
+        assert!(result.is_err());
+        assert!(matches!(result, Err(LlmClientError::ApiError { .. })));
+    }
+}


### PR DESCRIPTION
## Summary

This PR extracts shared LLM client logic into a runtime-agnostic crate, enabling code reuse across multiple runtimes.

## Changes

### New Crates

#### `crates/llm-client` - Shared LLM Logic
- **Provider enum**: OpenAI, Anthropic, OpenRouter with endpoints and auth headers
- **RequestBuilder**: Fluent API for constructing API requests
- **ResponseParser**: Parse responses and SSE streams for all providers
- **Message/Role types**: Conversation history management
- **20 tests** covering all functionality

#### `crates/fastly` - Fastly Compute Runtime
- **FastlyAgent**: Uses llm-client for request/response logic
- **Streaming support**: Via Fastly Body
- **Error handling**: Fastly-specific errors
- **2 tests** for configuration

## Architecture

```
                    ┌─────────────────┐
                    │   llm-client    │
                    │ (no runtime deps)│
                    └────────┬────────┘
                             │
           ┌─────────────────┼─────────────────┐
           │                 │                 │
    ┌──────▼──────┐   ┌──────▼──────┐   ┌──────▼──────┐
    │    wasm     │   │   fastly    │   │  (future)   │
    │  (web-sys)  │   │ (fastly SDK)│   │ cloudflare  │
    └─────────────┘   └─────────────┘   └─────────────┘
```

## Testing

```bash
cargo test -p rust-ai-agents-llm-client -p rust-ai-agents-fastly
# 22 tests passing
```

Closes #12