### PR TITLE
feat: add leptos-ai crate for Leptos framework integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "crates/github-ops",
     "crates/llm-client",
     "crates/fastly",
+    "crates/leptos-ai",
     "examples",
 ]
 

--- a/crates/leptos-ai/Cargo.toml
+++ b/crates/leptos-ai/Cargo.toml
@@ -1,0 +1,55 @@
+[package]
+name = "leptos-ai"
+version = "0.1.0"
+edition = "2021"
+description = "AI hooks for Leptos - chat, completions, and streaming"
+license = "Apache-2.0"
+authors = ["Ronaldo Lima"]
+repository = "https://github.com/limaronaldo/rust-ai-agents"
+keywords = ["ai", "leptos", "llm", "chat", "wasm"]
+categories = ["api-bindings", "wasm", "web-programming"]
+
+[dependencies]
+# Shared LLM client logic
+rust-ai-agents-llm-client = { path = "../llm-client" }
+
+# Leptos framework
+leptos = { version = "0.8", features = ["csr"] }
+
+# Serialization
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+# HTTP client for WASM
+gloo-net = { version = "0.6", features = ["http"] }
+
+# Futures and streaming
+futures = "0.3"
+wasm-streams = "0.4"
+
+# Web APIs
+web-sys = { version = "0.3", features = [
+    "Headers",
+    "Request",
+    "RequestInit",
+    "RequestMode",
+    "Response",
+    "ReadableStream",
+    "ReadableStreamDefaultReader",
+    "Window",
+] }
+wasm-bindgen = "0.2"
+js-sys = "0.3"
+wasm-bindgen-futures = "0.4"
+
+# Error handling
+thiserror = "1.0"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+
+[features]
+default = ["csr"]
+csr = ["leptos/csr"]
+ssr = ["leptos/ssr"]
+hydrate = ["leptos/hydrate"]

--- a/crates/leptos-ai/README.md
+++ b/crates/leptos-ai/README.md
@@ -1,0 +1,193 @@
+# leptos-ai
+
+AI hooks for Leptos applications - chat, completions, and streaming.
+
+## Features
+
+- `use_chat` - Reactive chat with message history and streaming
+- `use_completion` - Single completion requests  
+- Built on `llm-client` for provider support (OpenAI, Anthropic, OpenRouter)
+- Real-time streaming with `streaming_content` signal
+- Stop generation support
+
+## Installation
+
+```toml
+[dependencies]
+leptos-ai = { git = "https://github.com/limaronaldo/rust-ai-agents" }
+```
+
+## Usage
+
+### Chat Interface
+
+```rust
+use leptos::prelude::*;
+use leptos_ai::{use_chat, ChatOptions};
+
+#[component]
+fn Chat() -> impl IntoView {
+    let chat = use_chat(ChatOptions {
+        provider: "openai".to_string(),
+        api_key: "sk-...".to_string(),
+        model: "gpt-4o-mini".to_string(),
+        system_prompt: Some("You are a helpful assistant.".to_string()),
+        ..Default::default()
+    });
+
+    let input_ref = NodeRef::<leptos::html::Input>::new();
+
+    let on_submit = move |ev: leptos::ev::SubmitEvent| {
+        ev.prevent_default();
+        if let Some(input) = input_ref.get() {
+            let value = input.value();
+            if !value.is_empty() {
+                chat.send(&value);
+                input.set_value("");
+            }
+        }
+    };
+
+    view! {
+        <div class="chat">
+            // Message list
+            <For
+                each=move || chat.messages.get()
+                key=|msg| msg.id.clone()
+                children=move |msg| {
+                    view! {
+                        <div class=format!("message {}", msg.role)>
+                            {msg.content.clone()}
+                        </div>
+                    }
+                }
+            />
+
+            // Streaming indicator
+            <Show when=move || !chat.streaming_content.get().is_empty()>
+                <div class="message assistant streaming">
+                    {move || chat.streaming_content.get()}
+                </div>
+            </Show>
+
+            // Loading indicator
+            <Show when=move || chat.is_loading.get()>
+                <div class="loading">"..."</div>
+            </Show>
+
+            // Error display
+            <Show when=move || chat.error.get().is_some()>
+                <div class="error">
+                    {move || chat.error.get().unwrap_or_default()}
+                </div>
+            </Show>
+
+            // Input form
+            <form on:submit=on_submit>
+                <input 
+                    type="text" 
+                    node_ref=input_ref 
+                    placeholder="Type a message..."
+                    disabled=move || chat.is_loading.get()
+                />
+                <button type="submit" disabled=move || chat.is_loading.get()>
+                    "Send"
+                </button>
+                <button 
+                    type="button" 
+                    on:click=move |_| chat.stop()
+                    disabled=move || !chat.is_loading.get()
+                >
+                    "Stop"
+                </button>
+            </form>
+        </div>
+    }
+}
+```
+
+### Single Completion
+
+```rust
+use leptos::prelude::*;
+use leptos_ai::{use_completion, CompletionOptions};
+
+#[component]
+fn Translator() -> impl IntoView {
+    let completion = use_completion(CompletionOptions {
+        provider: "openai".to_string(),
+        api_key: "sk-...".to_string(),
+        model: "gpt-4o-mini".to_string(),
+        system_prompt: Some("You are a translator. Translate to Spanish.".to_string()),
+        ..Default::default()
+    });
+
+    let input_ref = NodeRef::<leptos::html::Input>::new();
+
+    let on_translate = move |_| {
+        if let Some(input) = input_ref.get() {
+            completion.complete(&input.value());
+        }
+    };
+
+    view! {
+        <div>
+            <input type="text" node_ref=input_ref placeholder="Enter text..." />
+            <button on:click=on_translate disabled=move || completion.is_loading.get()>
+                "Translate"
+            </button>
+            
+            <Show when=move || completion.completion.get().is_some()>
+                <p><strong>"Translation: "</strong>{move || completion.completion.get()}</p>
+            </Show>
+        </div>
+    }
+}
+```
+
+## API Reference
+
+### `use_chat(options: ChatOptions) -> UseChat`
+
+Creates a reactive chat interface.
+
+**ChatOptions:**
+- `provider` - "openai", "anthropic", or "openrouter"
+- `api_key` - Your API key
+- `model` - Model identifier (e.g., "gpt-4o-mini")
+- `system_prompt` - Optional system prompt
+- `temperature` - 0.0 to 2.0 (default: 0.7)
+- `max_tokens` - Maximum tokens (default: 4096)
+- `stream` - Enable streaming (default: true)
+- `initial_messages` - Pre-populate chat history
+
+**UseChat:**
+- `messages: RwSignal<Vec<ChatMessage>>` - Chat history
+- `is_loading: RwSignal<bool>` - Request in progress
+- `error: RwSignal<Option<String>>` - Current error
+- `streaming_content: RwSignal<String>` - Real-time streaming text
+- `send(&str)` - Send a message
+- `clear()` - Clear history
+- `stop()` - Stop generation
+
+### `use_completion(options: CompletionOptions) -> UseCompletion`
+
+Creates a single completion interface.
+
+**UseCompletion:**
+- `completion: RwSignal<Option<String>>` - The result
+- `is_loading: RwSignal<bool>` - Request in progress
+- `error: RwSignal<Option<String>>` - Current error
+- `complete(&str)` - Request completion
+
+## Providers
+
+| Provider | Models |
+|----------|--------|
+| OpenAI | gpt-4o, gpt-4o-mini, gpt-4-turbo, gpt-3.5-turbo |
+| Anthropic | claude-3-opus, claude-3-sonnet, claude-3-haiku |
+| OpenRouter | 100+ models from various providers |
+
+## License
+
+Apache-2.0

--- a/crates/leptos-ai/src/error.rs
+++ b/crates/leptos-ai/src/error.rs
@@ -1,0 +1,51 @@
+//! Error types for leptos-ai
+
+use thiserror::Error;
+
+/// Errors that can occur in leptos-ai
+#[derive(Debug, Error, Clone)]
+pub enum LeptosAiError {
+    /// HTTP request failed
+    #[error("Request failed: {0}")]
+    RequestFailed(String),
+
+    /// Invalid provider
+    #[error("Invalid provider: {0}")]
+    InvalidProvider(String),
+
+    /// API error response
+    #[error("API error: {0}")]
+    ApiError(String),
+
+    /// Parse error
+    #[error("Parse error: {0}")]
+    ParseError(String),
+
+    /// Stream error
+    #[error("Stream error: {0}")]
+    StreamError(String),
+
+    /// Missing configuration
+    #[error("Missing configuration: {0}")]
+    MissingConfig(String),
+}
+
+impl From<gloo_net::Error> for LeptosAiError {
+    fn from(e: gloo_net::Error) -> Self {
+        LeptosAiError::RequestFailed(e.to_string())
+    }
+}
+
+impl From<serde_json::Error> for LeptosAiError {
+    fn from(e: serde_json::Error) -> Self {
+        LeptosAiError::ParseError(e.to_string())
+    }
+}
+
+impl From<rust_ai_agents_llm_client::LlmClientError> for LeptosAiError {
+    fn from(e: rust_ai_agents_llm_client::LlmClientError) -> Self {
+        LeptosAiError::ApiError(e.to_string())
+    }
+}
+
+pub type Result<T> = std::result::Result<T, LeptosAiError>;

--- a/crates/leptos-ai/src/hooks.rs
+++ b/crates/leptos-ai/src/hooks.rs
@@ -1,0 +1,441 @@
+//! Reactive hooks for Leptos AI
+
+use leptos::prelude::*;
+use rust_ai_agents_llm_client::{Message, Provider, RequestBuilder, ResponseParser};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::JsFuture;
+use web_sys::{Request, RequestInit, RequestMode, Response};
+
+use crate::{ChatMessage, ChatOptions, CompletionOptions, LeptosAiError, Result};
+
+/// Return type for use_chat hook
+#[derive(Clone, Copy)]
+pub struct UseChat {
+    /// Reactive list of messages
+    pub messages: RwSignal<Vec<ChatMessage>>,
+    /// Whether a request is in progress
+    pub is_loading: RwSignal<bool>,
+    /// Current error, if any
+    pub error: RwSignal<Option<String>>,
+    /// Current streaming content (updated in real-time)
+    pub streaming_content: RwSignal<String>,
+    /// Internal: options stored
+    options: RwSignal<ChatOptions>,
+    /// Internal: stop flag
+    should_stop: RwSignal<bool>,
+}
+
+impl UseChat {
+    /// Send a message to the chat
+    pub fn send(&self, message: &str) {
+        let opts = self.options.get_untracked();
+        let messages_signal = self.messages;
+        let is_loading = self.is_loading;
+        let error = self.error;
+        let streaming_content = self.streaming_content;
+        let should_stop = self.should_stop;
+
+        // Add user message
+        let user_msg = ChatMessage::user(message);
+        messages_signal.update(|msgs| msgs.push(user_msg));
+
+        // Reset state
+        is_loading.set(true);
+        error.set(None);
+        streaming_content.set(String::new());
+        should_stop.set(false);
+
+        let current_messages = messages_signal.get_untracked();
+
+        // Spawn the async request
+        leptos::task::spawn_local(async move {
+            let result = if opts.stream {
+                send_streaming_request(&opts, current_messages, streaming_content, should_stop)
+                    .await
+            } else {
+                send_request(&opts, current_messages).await
+            };
+
+            match result {
+                Ok(content) => {
+                    let assistant_msg = ChatMessage::assistant(content);
+                    messages_signal.update(|msgs| msgs.push(assistant_msg));
+                }
+                Err(e) => {
+                    error.set(Some(e.to_string()));
+                }
+            }
+
+            is_loading.set(false);
+            streaming_content.set(String::new());
+        });
+    }
+
+    /// Clear all messages
+    pub fn clear(&self) {
+        self.messages.set(Vec::new());
+        self.error.set(None);
+        self.streaming_content.set(String::new());
+    }
+
+    /// Stop the current generation
+    pub fn stop(&self) {
+        self.should_stop.set(true);
+    }
+}
+
+/// Create a reactive chat interface
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let chat = use_chat(ChatOptions {
+///     provider: "openai".to_string(),
+///     api_key: "sk-...".to_string(),
+///     model: "gpt-4o-mini".to_string(),
+///     ..Default::default()
+/// });
+///
+/// // Send a message
+/// chat.send("Hello!");
+///
+/// // Access messages reactively
+/// let messages = chat.messages.get();
+/// ```
+pub fn use_chat(options: ChatOptions) -> UseChat {
+    let messages = RwSignal::new(options.initial_messages.clone());
+    let is_loading = RwSignal::new(false);
+    let error = RwSignal::new(None::<String>);
+    let streaming_content = RwSignal::new(String::new());
+    let should_stop = RwSignal::new(false);
+    let options_signal = RwSignal::new(options);
+
+    UseChat {
+        messages,
+        is_loading,
+        error,
+        streaming_content,
+        options: options_signal,
+        should_stop,
+    }
+}
+
+/// Return type for use_completion hook
+#[derive(Clone, Copy)]
+pub struct UseCompletion {
+    /// The completion result
+    pub completion: RwSignal<Option<String>>,
+    /// Whether a request is in progress
+    pub is_loading: RwSignal<bool>,
+    /// Current error, if any
+    pub error: RwSignal<Option<String>>,
+    /// Internal: options
+    options: RwSignal<CompletionOptions>,
+}
+
+impl UseCompletion {
+    /// Request a completion
+    pub fn complete(&self, prompt: &str) {
+        let opts = self.options.get_untracked();
+        let completion = self.completion;
+        let is_loading = self.is_loading;
+        let error = self.error;
+        let prompt = prompt.to_string();
+
+        is_loading.set(true);
+        error.set(None);
+        completion.set(None);
+
+        leptos::task::spawn_local(async move {
+            let messages = vec![ChatMessage::user(&prompt)];
+
+            let chat_opts = ChatOptions {
+                provider: opts.provider,
+                api_key: opts.api_key,
+                model: opts.model,
+                system_prompt: opts.system_prompt,
+                temperature: opts.temperature,
+                max_tokens: opts.max_tokens,
+                stream: false,
+                initial_messages: Vec::new(),
+            };
+
+            match send_request(&chat_opts, messages).await {
+                Ok(content) => {
+                    completion.set(Some(content));
+                }
+                Err(e) => {
+                    error.set(Some(e.to_string()));
+                }
+            }
+
+            is_loading.set(false);
+        });
+    }
+}
+
+/// Create a completion interface for single requests
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let completion = use_completion(CompletionOptions {
+///     provider: "openai".to_string(),
+///     api_key: "sk-...".to_string(),
+///     model: "gpt-4o-mini".to_string(),
+///     ..Default::default()
+/// });
+///
+/// // Request a completion
+/// completion.complete("Translate 'hello' to Spanish");
+///
+/// // Access result reactively
+/// if let Some(result) = completion.completion.get() {
+///     println!("{}", result);
+/// }
+/// ```
+pub fn use_completion(options: CompletionOptions) -> UseCompletion {
+    let completion = RwSignal::new(None::<String>);
+    let is_loading = RwSignal::new(false);
+    let error = RwSignal::new(None::<String>);
+    let options_signal = RwSignal::new(options);
+
+    UseCompletion {
+        completion,
+        is_loading,
+        error,
+        options: options_signal,
+    }
+}
+
+/// Send a non-streaming request
+async fn send_request(options: &ChatOptions, messages: Vec<ChatMessage>) -> Result<String> {
+    let provider: Provider = options
+        .provider
+        .parse()
+        .map_err(|_| LeptosAiError::InvalidProvider(options.provider.clone()))?;
+
+    // Convert ChatMessage to llm-client Message
+    let mut llm_messages: Vec<Message> = Vec::new();
+
+    if let Some(ref system) = options.system_prompt {
+        llm_messages.push(Message::system(system));
+    }
+
+    for msg in &messages {
+        match msg.role.as_str() {
+            "user" => llm_messages.push(Message::user(&msg.content)),
+            "assistant" => llm_messages.push(Message::assistant(&msg.content)),
+            "system" => llm_messages.push(Message::system(&msg.content)),
+            _ => {}
+        }
+    }
+
+    // Build request using llm-client
+    let http_request = RequestBuilder::new(provider)
+        .model(&options.model)
+        .api_key(&options.api_key)
+        .messages(&llm_messages)
+        .temperature(options.temperature)
+        .max_tokens(options.max_tokens)
+        .stream(false)
+        .build()?;
+
+    // Send via web-sys fetch
+    let response = fetch(&http_request.url, &http_request.headers, &http_request.body).await?;
+
+    // Parse response using llm-client
+    let llm_response = ResponseParser::parse(provider, &response)?;
+
+    Ok(llm_response.content)
+}
+
+/// Send a streaming request
+async fn send_streaming_request(
+    options: &ChatOptions,
+    messages: Vec<ChatMessage>,
+    streaming_content: RwSignal<String>,
+    should_stop: RwSignal<bool>,
+) -> Result<String> {
+    let provider: Provider = options
+        .provider
+        .parse()
+        .map_err(|_| LeptosAiError::InvalidProvider(options.provider.clone()))?;
+
+    // Convert ChatMessage to llm-client Message
+    let mut llm_messages: Vec<Message> = Vec::new();
+
+    if let Some(ref system) = options.system_prompt {
+        llm_messages.push(Message::system(system));
+    }
+
+    for msg in &messages {
+        match msg.role.as_str() {
+            "user" => llm_messages.push(Message::user(&msg.content)),
+            "assistant" => llm_messages.push(Message::assistant(&msg.content)),
+            "system" => llm_messages.push(Message::system(&msg.content)),
+            _ => {}
+        }
+    }
+
+    // Build request using llm-client
+    let http_request = RequestBuilder::new(provider)
+        .model(&options.model)
+        .api_key(&options.api_key)
+        .messages(&llm_messages)
+        .temperature(options.temperature)
+        .max_tokens(options.max_tokens)
+        .stream(true)
+        .build()?;
+
+    // Send via web-sys fetch and get streaming response
+    let response =
+        fetch_stream(&http_request.url, &http_request.headers, &http_request.body).await?;
+
+    // Process SSE stream
+    let mut full_content = String::new();
+    let reader = response
+        .body()
+        .ok_or_else(|| LeptosAiError::StreamError("No response body".to_string()))?
+        .get_reader();
+
+    let reader: web_sys::ReadableStreamDefaultReader = reader.unchecked_into();
+
+    loop {
+        if should_stop.get_untracked() {
+            break;
+        }
+
+        let result = JsFuture::from(reader.read()).await;
+        let result = result.map_err(|e| LeptosAiError::StreamError(format!("{:?}", e)))?;
+
+        let done = js_sys::Reflect::get(&result, &JsValue::from_str("done"))
+            .map_err(|e| LeptosAiError::StreamError(format!("{:?}", e)))?
+            .as_bool()
+            .unwrap_or(true);
+
+        if done {
+            break;
+        }
+
+        let value = js_sys::Reflect::get(&result, &JsValue::from_str("value"))
+            .map_err(|e| LeptosAiError::StreamError(format!("{:?}", e)))?;
+
+        let array = js_sys::Uint8Array::new(&value);
+        let bytes = array.to_vec();
+        let text = String::from_utf8_lossy(&bytes);
+
+        // Parse SSE lines
+        for line in text.lines() {
+            if let Ok(Some(chunk)) = ResponseParser::parse_stream_line(provider, line) {
+                if let Some(content) = chunk.content {
+                    full_content.push_str(&content);
+                    streaming_content.set(full_content.clone());
+                }
+                if chunk.done {
+                    break;
+                }
+            }
+        }
+    }
+
+    Ok(full_content)
+}
+
+/// Fetch helper using web-sys
+async fn fetch(url: &str, headers: &[(String, String)], body: &str) -> Result<String> {
+    let opts = RequestInit::new();
+    opts.set_method("POST");
+    opts.set_mode(RequestMode::Cors);
+    opts.set_body(&JsValue::from_str(body));
+
+    let js_headers =
+        web_sys::Headers::new().map_err(|e| LeptosAiError::RequestFailed(format!("{:?}", e)))?;
+
+    for (key, value) in headers {
+        js_headers
+            .set(key, value)
+            .map_err(|e| LeptosAiError::RequestFailed(format!("{:?}", e)))?;
+    }
+    opts.set_headers(&js_headers);
+
+    let request = Request::new_with_str_and_init(url, &opts)
+        .map_err(|e| LeptosAiError::RequestFailed(format!("{:?}", e)))?;
+
+    let window =
+        web_sys::window().ok_or_else(|| LeptosAiError::RequestFailed("No window".to_string()))?;
+
+    let resp_value = JsFuture::from(window.fetch_with_request(&request))
+        .await
+        .map_err(|e| LeptosAiError::RequestFailed(format!("{:?}", e)))?;
+
+    let resp: Response = resp_value
+        .dyn_into()
+        .map_err(|e| LeptosAiError::RequestFailed(format!("{:?}", e)))?;
+
+    if !resp.ok() {
+        let status = resp.status();
+        let text = JsFuture::from(
+            resp.text()
+                .map_err(|e| LeptosAiError::RequestFailed(format!("{:?}", e)))?,
+        )
+        .await
+        .map_err(|e| LeptosAiError::RequestFailed(format!("{:?}", e)))?
+        .as_string()
+        .unwrap_or_default();
+        return Err(LeptosAiError::ApiError(format!(
+            "HTTP {}: {}",
+            status, text
+        )));
+    }
+
+    let text = JsFuture::from(
+        resp.text()
+            .map_err(|e| LeptosAiError::RequestFailed(format!("{:?}", e)))?,
+    )
+    .await
+    .map_err(|e| LeptosAiError::RequestFailed(format!("{:?}", e)))?
+    .as_string()
+    .unwrap_or_default();
+
+    Ok(text)
+}
+
+/// Fetch helper for streaming responses
+async fn fetch_stream(url: &str, headers: &[(String, String)], body: &str) -> Result<Response> {
+    let opts = RequestInit::new();
+    opts.set_method("POST");
+    opts.set_mode(RequestMode::Cors);
+    opts.set_body(&JsValue::from_str(body));
+
+    let js_headers =
+        web_sys::Headers::new().map_err(|e| LeptosAiError::RequestFailed(format!("{:?}", e)))?;
+
+    for (key, value) in headers {
+        js_headers
+            .set(key, value)
+            .map_err(|e| LeptosAiError::RequestFailed(format!("{:?}", e)))?;
+    }
+    opts.set_headers(&js_headers);
+
+    let request = Request::new_with_str_and_init(url, &opts)
+        .map_err(|e| LeptosAiError::RequestFailed(format!("{:?}", e)))?;
+
+    let window =
+        web_sys::window().ok_or_else(|| LeptosAiError::RequestFailed("No window".to_string()))?;
+
+    let resp_value = JsFuture::from(window.fetch_with_request(&request))
+        .await
+        .map_err(|e| LeptosAiError::RequestFailed(format!("{:?}", e)))?;
+
+    let resp: Response = resp_value
+        .dyn_into()
+        .map_err(|e| LeptosAiError::RequestFailed(format!("{:?}", e)))?;
+
+    if !resp.ok() {
+        let status = resp.status();
+        return Err(LeptosAiError::ApiError(format!("HTTP {}", status)));
+    }
+
+    Ok(resp)
+}

--- a/crates/leptos-ai/src/lib.rs
+++ b/crates/leptos-ai/src/lib.rs
@@ -1,0 +1,73 @@
+//! # Leptos AI
+//!
+//! AI hooks for Leptos applications - chat, completions, and streaming.
+//!
+//! ## Features
+//!
+//! - `use_chat` - Reactive chat with message history and streaming
+//! - `use_completion` - Single completion requests
+//! - Built on `llm-client` for provider support (OpenAI, Anthropic, OpenRouter)
+//!
+//! ## Example
+//!
+//! ```rust,ignore
+//! use leptos::*;
+//! use leptos_ai::{use_chat, ChatOptions};
+//!
+//! #[component]
+//! fn Chat() -> impl IntoView {
+//!     let chat = use_chat(ChatOptions {
+//!         provider: "openai".to_string(),
+//!         api_key: "sk-...".to_string(),
+//!         model: "gpt-4o-mini".to_string(),
+//!         ..Default::default()
+//!     });
+//!
+//!     let input = create_node_ref::<html::Input>();
+//!
+//!     let on_submit = move |ev: ev::SubmitEvent| {
+//!         ev.prevent_default();
+//!         if let Some(input_el) = input.get() {
+//!             let value = input_el.value();
+//!             if !value.is_empty() {
+//!                 chat.send(&value);
+//!                 input_el.set_value("");
+//!             }
+//!         }
+//!     };
+//!
+//!     view! {
+//!         <div class="chat">
+//!             <For
+//!                 each=move || chat.messages.get()
+//!                 key=|msg| msg.id.clone()
+//!                 children=move |msg| {
+//!                     view! {
+//!                         <div class=format!("message {}", msg.role)>
+//!                             {msg.content.clone()}
+//!                         </div>
+//!                     }
+//!                 }
+//!             />
+//!             <Show when=move || chat.is_loading.get()>
+//!                 <div class="loading">"Thinking..."</div>
+//!             </Show>
+//!             <form on:submit=on_submit>
+//!                 <input type="text" node_ref=input placeholder="Type a message..." />
+//!                 <button type="submit">"Send"</button>
+//!             </form>
+//!         </div>
+//!     }
+//! }
+//! ```
+
+mod error;
+mod hooks;
+mod types;
+
+pub use error::*;
+pub use hooks::*;
+pub use types::*;
+
+// Re-export useful types from llm-client
+pub use rust_ai_agents_llm_client::{Provider, Role};

--- a/crates/leptos-ai/src/types.rs
+++ b/crates/leptos-ai/src/types.rs
@@ -1,0 +1,141 @@
+//! Types for leptos-ai
+
+use serde::{Deserialize, Serialize};
+
+/// A message in the chat conversation
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ChatMessage {
+    /// Unique identifier for the message
+    pub id: String,
+    /// Role: "user", "assistant", or "system"
+    pub role: String,
+    /// Message content
+    pub content: String,
+    /// Timestamp when created
+    pub created_at: f64,
+}
+
+impl ChatMessage {
+    /// Create a new user message
+    pub fn user(content: impl Into<String>) -> Self {
+        Self {
+            id: generate_id(),
+            role: "user".to_string(),
+            content: content.into(),
+            created_at: now(),
+        }
+    }
+
+    /// Create a new assistant message
+    pub fn assistant(content: impl Into<String>) -> Self {
+        Self {
+            id: generate_id(),
+            role: "assistant".to_string(),
+            content: content.into(),
+            created_at: now(),
+        }
+    }
+
+    /// Create a new system message
+    pub fn system(content: impl Into<String>) -> Self {
+        Self {
+            id: generate_id(),
+            role: "system".to_string(),
+            content: content.into(),
+            created_at: now(),
+        }
+    }
+}
+
+/// Options for the chat hook
+#[derive(Debug, Clone)]
+pub struct ChatOptions {
+    /// LLM provider: "openai", "anthropic", "openrouter"
+    pub provider: String,
+    /// API key
+    pub api_key: String,
+    /// Model identifier (e.g., "gpt-4o-mini", "claude-3-sonnet")
+    pub model: String,
+    /// System prompt
+    pub system_prompt: Option<String>,
+    /// Temperature (0.0 - 2.0)
+    pub temperature: f32,
+    /// Maximum tokens to generate
+    pub max_tokens: u32,
+    /// Enable streaming
+    pub stream: bool,
+    /// Initial messages
+    pub initial_messages: Vec<ChatMessage>,
+}
+
+impl Default for ChatOptions {
+    fn default() -> Self {
+        Self {
+            provider: "openai".to_string(),
+            api_key: String::new(),
+            model: "gpt-4o-mini".to_string(),
+            system_prompt: None,
+            temperature: 0.7,
+            max_tokens: 4096,
+            stream: true,
+            initial_messages: Vec::new(),
+        }
+    }
+}
+
+/// Options for the completion hook
+#[derive(Debug, Clone)]
+pub struct CompletionOptions {
+    /// LLM provider: "openai", "anthropic", "openrouter"
+    pub provider: String,
+    /// API key
+    pub api_key: String,
+    /// Model identifier
+    pub model: String,
+    /// System prompt
+    pub system_prompt: Option<String>,
+    /// Temperature (0.0 - 2.0)
+    pub temperature: f32,
+    /// Maximum tokens to generate
+    pub max_tokens: u32,
+}
+
+impl Default for CompletionOptions {
+    fn default() -> Self {
+        Self {
+            provider: "openai".to_string(),
+            api_key: String::new(),
+            model: "gpt-4o-mini".to_string(),
+            system_prompt: None,
+            temperature: 0.7,
+            max_tokens: 4096,
+        }
+    }
+}
+
+/// Token usage information
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TokenUsage {
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub total_tokens: u32,
+}
+
+/// Generate a unique ID
+fn generate_id() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!("msg_{}", timestamp)
+}
+
+/// Get current timestamp
+fn now() -> f64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs_f64()
+}


### PR DESCRIPTION
## Summary

Add `leptos-ai` crate with reactive AI hooks for Leptos 0.8 applications.

## Features

- **`use_chat()`** - Reactive chat interface with:
  - Message history management
  - Real-time streaming via `streaming_content` signal
  - Stop generation support
  - Error handling

- **`use_completion()`** - Single completion requests

- **Provider Support** (via `llm-client`):
  - OpenAI (gpt-4o, gpt-4o-mini, etc.)
  - Anthropic (claude-3-opus, claude-3-sonnet, etc.)
  - OpenRouter (100+ models)

## Usage Example

```rust
use leptos::prelude::*;
use leptos_ai::{use_chat, ChatOptions};

#[component]
fn Chat() -> impl IntoView {
    let chat = use_chat(ChatOptions {
        provider: "openai".to_string(),
        api_key: "sk-...".to_string(),
        model: "gpt-4o-mini".to_string(),
        ..Default::default()
    });

    view! {
        <For each=move || chat.messages.get() key=|m| m.id.clone()>
            {|msg| view! { <p>{msg.content}</p> }}
        </For>
        <button on:click=move |_| chat.send("Hello!")>"Send"</button>
    }
}
```

## Files

- `crates/leptos-ai/Cargo.toml` - Dependencies (Leptos 0.8, llm-client)
- `crates/leptos-ai/src/lib.rs` - Module exports
- `crates/leptos-ai/src/hooks.rs` - use_chat, use_completion
- `crates/leptos-ai/src/types.rs` - ChatMessage, ChatOptions
- `crates/leptos-ai/src/error.rs` - Error types
- `crates/leptos-ai/README.md` - Documentation

## Testing

```bash
cargo build -p leptos-ai
cargo clippy -p leptos-ai -- -D warnings
```

Closes #30