### PR TITLE
feat: add dioxus-ai crate for Dioxus framework integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/llm-client",
     "crates/fastly",
     "crates/leptos-ai",
+    "crates/dioxus-ai",
     "examples",
 ]
 

--- a/crates/dioxus-ai/Cargo.toml
+++ b/crates/dioxus-ai/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "dioxus-ai"
+version = "0.1.0"
+edition = "2021"
+description = "AI hooks for Dioxus - chat, completions, and streaming"
+license = "Apache-2.0"
+authors = ["Ronaldo Lima"]
+repository = "https://github.com/limaronaldo/rust-ai-agents"
+keywords = ["ai", "dioxus", "llm", "chat", "wasm"]
+categories = ["api-bindings", "wasm", "web-programming"]
+
+[dependencies]
+# Shared LLM client logic
+rust-ai-agents-llm-client = { path = "../llm-client" }
+
+# Dioxus framework
+dioxus = { version = "0.6", features = ["web"] }
+
+# Serialization
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+# Futures
+futures = "0.3"
+
+# Web APIs (for WASM)
+web-sys = { version = "0.3", features = [
+    "Headers",
+    "Request",
+    "RequestInit",
+    "RequestMode",
+    "Response",
+    "ReadableStream",
+    "ReadableStreamDefaultReader",
+    "Window",
+] }
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+js-sys = "0.3"
+
+# Error handling
+thiserror = "1.0"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+
+[features]
+default = ["web"]
+web = ["dioxus/web"]
+desktop = ["dioxus/desktop"]

--- a/crates/dioxus-ai/README.md
+++ b/crates/dioxus-ai/README.md
@@ -1,0 +1,185 @@
+# dioxus-ai
+
+AI hooks for Dioxus applications - chat, completions, and streaming.
+
+## Features
+
+- `use_chat` - Reactive chat with message history and streaming
+- `use_completion` - Single completion requests
+- Built on `llm-client` for provider support (OpenAI, Anthropic, OpenRouter)
+- Real-time streaming with `streaming_content()` method
+- Stop generation support
+
+## Installation
+
+```toml
+[dependencies]
+dioxus-ai = { git = "https://github.com/limaronaldo/rust-ai-agents" }
+```
+
+## Usage
+
+### Chat Interface
+
+```rust
+use dioxus::prelude::*;
+use dioxus_ai::{use_chat, ChatOptions};
+
+#[component]
+fn Chat() -> Element {
+    let mut chat = use_chat(ChatOptions {
+        provider: "openai".to_string(),
+        api_key: "sk-...".to_string(),
+        model: "gpt-4o-mini".to_string(),
+        system_prompt: Some("You are a helpful assistant.".to_string()),
+        ..Default::default()
+    });
+
+    let mut input = use_signal(String::new);
+
+    rsx! {
+        div { class: "chat",
+            // Message list
+            for msg in chat.messages().iter() {
+                div { class: "message {msg.role}",
+                    "{msg.content}"
+                }
+            }
+
+            // Streaming indicator
+            if !chat.streaming_content().is_empty() {
+                div { class: "message assistant streaming",
+                    "{chat.streaming_content()}"
+                }
+            }
+
+            // Loading indicator
+            if chat.is_loading() {
+                div { class: "loading", "..." }
+            }
+
+            // Error display
+            if let Some(err) = chat.error() {
+                div { class: "error", "{err}" }
+            }
+
+            // Input form
+            form {
+                onsubmit: move |e| {
+                    e.prevent_default();
+                    if !input().is_empty() {
+                        chat.send(&input());
+                        input.set(String::new());
+                    }
+                },
+                input {
+                    r#type: "text",
+                    value: "{input}",
+                    oninput: move |e| input.set(e.value().clone()),
+                    placeholder: "Type a message...",
+                    disabled: chat.is_loading()
+                }
+                button { r#type: "submit", disabled: chat.is_loading(), "Send" }
+                button {
+                    r#type: "button",
+                    onclick: move |_| chat.stop(),
+                    disabled: !chat.is_loading(),
+                    "Stop"
+                }
+            }
+        }
+    }
+}
+```
+
+### Single Completion
+
+```rust
+use dioxus::prelude::*;
+use dioxus_ai::{use_completion, CompletionOptions};
+
+#[component]
+fn Translator() -> Element {
+    let mut completion = use_completion(CompletionOptions {
+        provider: "openai".to_string(),
+        api_key: "sk-...".to_string(),
+        model: "gpt-4o-mini".to_string(),
+        system_prompt: Some("You are a translator. Translate to Spanish.".to_string()),
+        ..Default::default()
+    });
+
+    let mut input = use_signal(String::new);
+
+    rsx! {
+        div {
+            input {
+                r#type: "text",
+                value: "{input}",
+                oninput: move |e| input.set(e.value().clone()),
+                placeholder: "Enter text..."
+            }
+            button {
+                onclick: move |_| completion.complete(&input()),
+                disabled: completion.is_loading(),
+                "Translate"
+            }
+
+            if let Some(result) = completion.completion() {
+                p { strong { "Translation: " } "{result}" }
+            }
+        }
+    }
+}
+```
+
+## API Reference
+
+### `use_chat(options: ChatOptions) -> UseChatState`
+
+Creates a reactive chat interface.
+
+**ChatOptions:**
+- `provider` - "openai", "anthropic", or "openrouter"
+- `api_key` - Your API key
+- `model` - Model identifier (e.g., "gpt-4o-mini")
+- `system_prompt` - Optional system prompt
+- `temperature` - 0.0 to 2.0 (default: 0.7)
+- `max_tokens` - Maximum tokens (default: 4096)
+- `stream` - Enable streaming (default: true)
+- `initial_messages` - Pre-populate chat history
+
+**UseChatState:**
+- `messages()` - Get chat history
+- `is_loading()` - Check if request in progress
+- `error()` - Get current error
+- `streaming_content()` - Get real-time streaming text
+- `send(&str)` - Send a message
+- `clear()` - Clear history
+- `stop()` - Stop generation
+
+### `use_completion(options: CompletionOptions) -> UseCompletionState`
+
+Creates a single completion interface.
+
+**UseCompletionState:**
+- `completion()` - Get the result
+- `is_loading()` - Check if request in progress
+- `error()` - Get current error
+- `complete(&str)` - Request completion
+
+## Providers
+
+| Provider | Models |
+|----------|--------|
+| OpenAI | gpt-4o, gpt-4o-mini, gpt-4-turbo, gpt-3.5-turbo |
+| Anthropic | claude-3-opus, claude-3-sonnet, claude-3-haiku |
+| OpenRouter | 100+ models from various providers |
+
+## Platform Support
+
+- **Web** (default) - WASM with web-sys fetch
+- **Desktop** - Coming soon (requires different HTTP client)
+
+## License
+
+Apache-2.0

--- a/crates/dioxus-ai/src/error.rs
+++ b/crates/dioxus-ai/src/error.rs
@@ -1,0 +1,45 @@
+//! Error types for dioxus-ai
+
+use thiserror::Error;
+
+/// Errors that can occur in dioxus-ai
+#[derive(Debug, Error, Clone)]
+pub enum DioxusAiError {
+    /// HTTP request failed
+    #[error("Request failed: {0}")]
+    RequestFailed(String),
+
+    /// Invalid provider
+    #[error("Invalid provider: {0}")]
+    InvalidProvider(String),
+
+    /// API error response
+    #[error("API error: {0}")]
+    ApiError(String),
+
+    /// Parse error
+    #[error("Parse error: {0}")]
+    ParseError(String),
+
+    /// Stream error
+    #[error("Stream error: {0}")]
+    StreamError(String),
+
+    /// Missing configuration
+    #[error("Missing configuration: {0}")]
+    MissingConfig(String),
+}
+
+impl From<serde_json::Error> for DioxusAiError {
+    fn from(e: serde_json::Error) -> Self {
+        DioxusAiError::ParseError(e.to_string())
+    }
+}
+
+impl From<rust_ai_agents_llm_client::LlmClientError> for DioxusAiError {
+    fn from(e: rust_ai_agents_llm_client::LlmClientError) -> Self {
+        DioxusAiError::ApiError(e.to_string())
+    }
+}
+
+pub type Result<T> = std::result::Result<T, DioxusAiError>;

--- a/crates/dioxus-ai/src/hooks.rs
+++ b/crates/dioxus-ai/src/hooks.rs
@@ -1,0 +1,429 @@
+//! Reactive hooks for Dioxus AI
+
+use dioxus::prelude::*;
+use rust_ai_agents_llm_client::{Message, Provider, RequestBuilder, ResponseParser};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::JsFuture;
+use web_sys::{Request, RequestInit, RequestMode, Response};
+
+use crate::{ChatMessage, ChatOptions, CompletionOptions, DioxusAiError, Result};
+
+/// State for the chat hook
+#[derive(Clone)]
+pub struct UseChatState {
+    messages: Signal<Vec<ChatMessage>>,
+    is_loading: Signal<bool>,
+    error: Signal<Option<String>>,
+    streaming_content: Signal<String>,
+    should_stop: Signal<bool>,
+    options: ChatOptions,
+}
+
+impl UseChatState {
+    /// Get current messages
+    pub fn messages(&self) -> Vec<ChatMessage> {
+        (self.messages)()
+    }
+
+    /// Check if loading
+    pub fn is_loading(&self) -> bool {
+        (self.is_loading)()
+    }
+
+    /// Get current error
+    pub fn error(&self) -> Option<String> {
+        (self.error)()
+    }
+
+    /// Get streaming content
+    pub fn streaming_content(&self) -> String {
+        (self.streaming_content)()
+    }
+
+    /// Send a message
+    pub fn send(&mut self, message: &str) {
+        let user_msg = ChatMessage::user(message);
+        let mut messages = self.messages;
+        let mut is_loading = self.is_loading;
+        let mut error = self.error;
+        let mut streaming_content = self.streaming_content;
+        let mut should_stop = self.should_stop;
+        let options = self.options.clone();
+
+        // Add user message
+        messages.write().push(user_msg);
+
+        // Reset state
+        is_loading.set(true);
+        error.set(None);
+        streaming_content.set(String::new());
+        should_stop.set(false);
+
+        let current_messages = messages();
+
+        // Spawn async request
+        spawn(async move {
+            let result = if options.stream {
+                send_streaming_request(&options, current_messages, streaming_content, should_stop).await
+            } else {
+                send_request(&options, current_messages).await
+            };
+
+            match result {
+                Ok(content) => {
+                    let assistant_msg = ChatMessage::assistant(content);
+                    messages.write().push(assistant_msg);
+                }
+                Err(e) => {
+                    error.set(Some(e.to_string()));
+                }
+            }
+
+            is_loading.set(false);
+            streaming_content.set(String::new());
+        });
+    }
+
+    /// Clear all messages
+    pub fn clear(&mut self) {
+        self.messages.write().clear();
+        self.error.set(None);
+        self.streaming_content.set(String::new());
+    }
+
+    /// Stop generation
+    pub fn stop(&mut self) {
+        self.should_stop.set(true);
+    }
+}
+
+/// Create a reactive chat interface
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let mut chat = use_chat(ChatOptions {
+///     provider: "openai".to_string(),
+///     api_key: "sk-...".to_string(),
+///     model: "gpt-4o-mini".to_string(),
+///     ..Default::default()
+/// });
+///
+/// chat.send("Hello!");
+/// ```
+pub fn use_chat(options: ChatOptions) -> UseChatState {
+    let messages = use_signal(|| options.initial_messages.clone());
+    let is_loading = use_signal(|| false);
+    let error = use_signal(|| None::<String>);
+    let streaming_content = use_signal(String::new);
+    let should_stop = use_signal(|| false);
+
+    UseChatState {
+        messages,
+        is_loading,
+        error,
+        streaming_content,
+        should_stop,
+        options,
+    }
+}
+
+/// State for the completion hook
+#[derive(Clone)]
+pub struct UseCompletionState {
+    completion: Signal<Option<String>>,
+    is_loading: Signal<bool>,
+    error: Signal<Option<String>>,
+    options: CompletionOptions,
+}
+
+impl UseCompletionState {
+    /// Get completion result
+    pub fn completion(&self) -> Option<String> {
+        (self.completion)()
+    }
+
+    /// Check if loading
+    pub fn is_loading(&self) -> bool {
+        (self.is_loading)()
+    }
+
+    /// Get current error
+    pub fn error(&self) -> Option<String> {
+        (self.error)()
+    }
+
+    /// Request a completion
+    pub fn complete(&mut self, prompt: &str) {
+        let mut completion = self.completion;
+        let mut is_loading = self.is_loading;
+        let mut error = self.error;
+        let options = self.options.clone();
+        let prompt = prompt.to_string();
+
+        is_loading.set(true);
+        error.set(None);
+        completion.set(None);
+
+        spawn(async move {
+            let messages = vec![ChatMessage::user(&prompt)];
+
+            let chat_opts = ChatOptions {
+                provider: options.provider,
+                api_key: options.api_key,
+                model: options.model,
+                system_prompt: options.system_prompt,
+                temperature: options.temperature,
+                max_tokens: options.max_tokens,
+                stream: false,
+                initial_messages: Vec::new(),
+            };
+
+            match send_request(&chat_opts, messages).await {
+                Ok(content) => {
+                    completion.set(Some(content));
+                }
+                Err(e) => {
+                    error.set(Some(e.to_string()));
+                }
+            }
+
+            is_loading.set(false);
+        });
+    }
+}
+
+/// Create a completion interface
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let mut completion = use_completion(CompletionOptions {
+///     provider: "openai".to_string(),
+///     api_key: "sk-...".to_string(),
+///     model: "gpt-4o-mini".to_string(),
+///     ..Default::default()
+/// });
+///
+/// completion.complete("Translate 'hello' to Spanish");
+/// ```
+pub fn use_completion(options: CompletionOptions) -> UseCompletionState {
+    let completion = use_signal(|| None::<String>);
+    let is_loading = use_signal(|| false);
+    let error = use_signal(|| None::<String>);
+
+    UseCompletionState {
+        completion,
+        is_loading,
+        error,
+        options,
+    }
+}
+
+/// Send a non-streaming request
+async fn send_request(options: &ChatOptions, messages: Vec<ChatMessage>) -> Result<String> {
+    let provider: Provider = options
+        .provider
+        .parse()
+        .map_err(|_| DioxusAiError::InvalidProvider(options.provider.clone()))?;
+
+    let mut llm_messages: Vec<Message> = Vec::new();
+
+    if let Some(ref system) = options.system_prompt {
+        llm_messages.push(Message::system(system));
+    }
+
+    for msg in &messages {
+        match msg.role.as_str() {
+            "user" => llm_messages.push(Message::user(&msg.content)),
+            "assistant" => llm_messages.push(Message::assistant(&msg.content)),
+            "system" => llm_messages.push(Message::system(&msg.content)),
+            _ => {}
+        }
+    }
+
+    let http_request = RequestBuilder::new(provider)
+        .model(&options.model)
+        .api_key(&options.api_key)
+        .messages(&llm_messages)
+        .temperature(options.temperature)
+        .max_tokens(options.max_tokens)
+        .stream(false)
+        .build()?;
+
+    let response = fetch(&http_request.url, &http_request.headers, &http_request.body).await?;
+    let llm_response = ResponseParser::parse(provider, &response)?;
+
+    Ok(llm_response.content)
+}
+
+/// Send a streaming request
+async fn send_streaming_request(
+    options: &ChatOptions,
+    messages: Vec<ChatMessage>,
+    mut streaming_content: Signal<String>,
+    should_stop: Signal<bool>,
+) -> Result<String> {
+    let provider: Provider = options
+        .provider
+        .parse()
+        .map_err(|_| DioxusAiError::InvalidProvider(options.provider.clone()))?;
+
+    let mut llm_messages: Vec<Message> = Vec::new();
+
+    if let Some(ref system) = options.system_prompt {
+        llm_messages.push(Message::system(system));
+    }
+
+    for msg in &messages {
+        match msg.role.as_str() {
+            "user" => llm_messages.push(Message::user(&msg.content)),
+            "assistant" => llm_messages.push(Message::assistant(&msg.content)),
+            "system" => llm_messages.push(Message::system(&msg.content)),
+            _ => {}
+        }
+    }
+
+    let http_request = RequestBuilder::new(provider)
+        .model(&options.model)
+        .api_key(&options.api_key)
+        .messages(&llm_messages)
+        .temperature(options.temperature)
+        .max_tokens(options.max_tokens)
+        .stream(true)
+        .build()?;
+
+    let response = fetch_stream(&http_request.url, &http_request.headers, &http_request.body).await?;
+
+    let mut full_content = String::new();
+    let reader = response
+        .body()
+        .ok_or_else(|| DioxusAiError::StreamError("No response body".to_string()))?
+        .get_reader();
+
+    let reader: web_sys::ReadableStreamDefaultReader = reader.unchecked_into();
+
+    loop {
+        if should_stop() {
+            break;
+        }
+
+        let result = JsFuture::from(reader.read()).await;
+        let result = result.map_err(|e| DioxusAiError::StreamError(format!("{:?}", e)))?;
+
+        let done = js_sys::Reflect::get(&result, &JsValue::from_str("done"))
+            .map_err(|e| DioxusAiError::StreamError(format!("{:?}", e)))?
+            .as_bool()
+            .unwrap_or(true);
+
+        if done {
+            break;
+        }
+
+        let value = js_sys::Reflect::get(&result, &JsValue::from_str("value"))
+            .map_err(|e| DioxusAiError::StreamError(format!("{:?}", e)))?;
+
+        let array = js_sys::Uint8Array::new(&value);
+        let bytes = array.to_vec();
+        let text = String::from_utf8_lossy(&bytes);
+
+        for line in text.lines() {
+            if let Ok(Some(chunk)) = ResponseParser::parse_stream_line(provider, line) {
+                if let Some(content) = chunk.content {
+                    full_content.push_str(&content);
+                    streaming_content.set(full_content.clone());
+                }
+                if chunk.done {
+                    break;
+                }
+            }
+        }
+    }
+
+    Ok(full_content)
+}
+
+async fn fetch(url: &str, headers: &[(String, String)], body: &str) -> Result<String> {
+    let opts = RequestInit::new();
+    opts.set_method("POST");
+    opts.set_mode(RequestMode::Cors);
+    opts.set_body(&JsValue::from_str(body));
+
+    let js_headers = web_sys::Headers::new()
+        .map_err(|e| DioxusAiError::RequestFailed(format!("{:?}", e)))?;
+
+    for (key, value) in headers {
+        js_headers
+            .set(key, value)
+            .map_err(|e| DioxusAiError::RequestFailed(format!("{:?}", e)))?;
+    }
+    opts.set_headers(&js_headers);
+
+    let request = Request::new_with_str_and_init(url, &opts)
+        .map_err(|e| DioxusAiError::RequestFailed(format!("{:?}", e)))?;
+
+    let window = web_sys::window().ok_or_else(|| DioxusAiError::RequestFailed("No window".to_string()))?;
+
+    let resp_value = JsFuture::from(window.fetch_with_request(&request))
+        .await
+        .map_err(|e| DioxusAiError::RequestFailed(format!("{:?}", e)))?;
+
+    let resp: Response = resp_value
+        .dyn_into()
+        .map_err(|e| DioxusAiError::RequestFailed(format!("{:?}", e)))?;
+
+    if !resp.ok() {
+        let status = resp.status();
+        let text = JsFuture::from(resp.text().map_err(|e| DioxusAiError::RequestFailed(format!("{:?}", e)))?)
+            .await
+            .map_err(|e| DioxusAiError::RequestFailed(format!("{:?}", e)))?
+            .as_string()
+            .unwrap_or_default();
+        return Err(DioxusAiError::ApiError(format!("HTTP {}: {}", status, text)));
+    }
+
+    let text = JsFuture::from(resp.text().map_err(|e| DioxusAiError::RequestFailed(format!("{:?}", e)))?)
+        .await
+        .map_err(|e| DioxusAiError::RequestFailed(format!("{:?}", e)))?
+        .as_string()
+        .unwrap_or_default();
+
+    Ok(text)
+}
+
+async fn fetch_stream(url: &str, headers: &[(String, String)], body: &str) -> Result<Response> {
+    let opts = RequestInit::new();
+    opts.set_method("POST");
+    opts.set_mode(RequestMode::Cors);
+    opts.set_body(&JsValue::from_str(body));
+
+    let js_headers = web_sys::Headers::new()
+        .map_err(|e| DioxusAiError::RequestFailed(format!("{:?}", e)))?;
+
+    for (key, value) in headers {
+        js_headers
+            .set(key, value)
+            .map_err(|e| DioxusAiError::RequestFailed(format!("{:?}", e)))?;
+    }
+    opts.set_headers(&js_headers);
+
+    let request = Request::new_with_str_and_init(url, &opts)
+        .map_err(|e| DioxusAiError::RequestFailed(format!("{:?}", e)))?;
+
+    let window = web_sys::window().ok_or_else(|| DioxusAiError::RequestFailed("No window".to_string()))?;
+
+    let resp_value = JsFuture::from(window.fetch_with_request(&request))
+        .await
+        .map_err(|e| DioxusAiError::RequestFailed(format!("{:?}", e)))?;
+
+    let resp: Response = resp_value
+        .dyn_into()
+        .map_err(|e| DioxusAiError::RequestFailed(format!("{:?}", e)))?;
+
+    if !resp.ok() {
+        let status = resp.status();
+        return Err(DioxusAiError::ApiError(format!("HTTP {}", status)));
+    }
+
+    Ok(resp)
+}

--- a/crates/dioxus-ai/src/lib.rs
+++ b/crates/dioxus-ai/src/lib.rs
@@ -1,0 +1,63 @@
+//! # Dioxus AI
+//!
+//! AI hooks for Dioxus applications - chat, completions, and streaming.
+//!
+//! ## Features
+//!
+//! - `use_chat` - Reactive chat with message history and streaming
+//! - `use_completion` - Single completion requests
+//! - Built on `llm-client` for provider support (OpenAI, Anthropic, OpenRouter)
+//!
+//! ## Example
+//!
+//! ```rust,ignore
+//! use dioxus::prelude::*;
+//! use dioxus_ai::{use_chat, ChatOptions};
+//!
+//! #[component]
+//! fn Chat() -> Element {
+//!     let mut chat = use_chat(ChatOptions {
+//!         provider: "openai".to_string(),
+//!         api_key: "sk-...".to_string(),
+//!         model: "gpt-4o-mini".to_string(),
+//!         ..Default::default()
+//!     });
+//!
+//!     let mut input = use_signal(String::new);
+//!
+//!     rsx! {
+//!         div {
+//!             for msg in chat.messages().iter() {
+//!                 p { class: "{msg.role}", "{msg.content}" }
+//!             }
+//!
+//!             if chat.is_loading() {
+//!                 p { "Thinking..." }
+//!             }
+//!
+//!             input {
+//!                 value: "{input}",
+//!                 oninput: move |e| input.set(e.value().clone())
+//!             }
+//!             button {
+//!                 onclick: move |_| {
+//!                     chat.send(&input());
+//!                     input.set(String::new());
+//!                 },
+//!                 "Send"
+//!             }
+//!         }
+//!     }
+//! }
+//! ```
+
+mod error;
+mod hooks;
+mod types;
+
+pub use error::*;
+pub use hooks::*;
+pub use types::*;
+
+// Re-export useful types from llm-client
+pub use rust_ai_agents_llm_client::{Provider, Role};

--- a/crates/dioxus-ai/src/types.rs
+++ b/crates/dioxus-ai/src/types.rs
@@ -1,0 +1,133 @@
+//! Types for dioxus-ai
+
+use serde::{Deserialize, Serialize};
+
+/// A message in the chat conversation
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ChatMessage {
+    /// Unique identifier for the message
+    pub id: String,
+    /// Role: "user", "assistant", or "system"
+    pub role: String,
+    /// Message content
+    pub content: String,
+    /// Timestamp when created
+    pub created_at: f64,
+}
+
+impl ChatMessage {
+    /// Create a new user message
+    pub fn user(content: impl Into<String>) -> Self {
+        Self {
+            id: generate_id(),
+            role: "user".to_string(),
+            content: content.into(),
+            created_at: now(),
+        }
+    }
+
+    /// Create a new assistant message
+    pub fn assistant(content: impl Into<String>) -> Self {
+        Self {
+            id: generate_id(),
+            role: "assistant".to_string(),
+            content: content.into(),
+            created_at: now(),
+        }
+    }
+
+    /// Create a new system message
+    pub fn system(content: impl Into<String>) -> Self {
+        Self {
+            id: generate_id(),
+            role: "system".to_string(),
+            content: content.into(),
+            created_at: now(),
+        }
+    }
+}
+
+/// Options for the chat hook
+#[derive(Debug, Clone)]
+pub struct ChatOptions {
+    /// LLM provider: "openai", "anthropic", "openrouter"
+    pub provider: String,
+    /// API key
+    pub api_key: String,
+    /// Model identifier (e.g., "gpt-4o-mini", "claude-3-sonnet")
+    pub model: String,
+    /// System prompt
+    pub system_prompt: Option<String>,
+    /// Temperature (0.0 - 2.0)
+    pub temperature: f32,
+    /// Maximum tokens to generate
+    pub max_tokens: u32,
+    /// Enable streaming
+    pub stream: bool,
+    /// Initial messages
+    pub initial_messages: Vec<ChatMessage>,
+}
+
+impl Default for ChatOptions {
+    fn default() -> Self {
+        Self {
+            provider: "openai".to_string(),
+            api_key: String::new(),
+            model: "gpt-4o-mini".to_string(),
+            system_prompt: None,
+            temperature: 0.7,
+            max_tokens: 4096,
+            stream: true,
+            initial_messages: Vec::new(),
+        }
+    }
+}
+
+/// Options for the completion hook
+#[derive(Debug, Clone)]
+pub struct CompletionOptions {
+    /// LLM provider: "openai", "anthropic", "openrouter"
+    pub provider: String,
+    /// API key
+    pub api_key: String,
+    /// Model identifier
+    pub model: String,
+    /// System prompt
+    pub system_prompt: Option<String>,
+    /// Temperature (0.0 - 2.0)
+    pub temperature: f32,
+    /// Maximum tokens to generate
+    pub max_tokens: u32,
+}
+
+impl Default for CompletionOptions {
+    fn default() -> Self {
+        Self {
+            provider: "openai".to_string(),
+            api_key: String::new(),
+            model: "gpt-4o-mini".to_string(),
+            system_prompt: None,
+            temperature: 0.7,
+            max_tokens: 4096,
+        }
+    }
+}
+
+/// Generate a unique ID
+fn generate_id() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!("msg_{}", timestamp)
+}
+
+/// Get current timestamp
+fn now() -> f64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs_f64()
+}


### PR DESCRIPTION
## Summary

Add `dioxus-ai` crate with reactive AI hooks for Dioxus 0.6 applications.

## Features

- **`use_chat()`** - Reactive chat interface with:
  - Message history management
  - Real-time streaming via `streaming_content()`
  - Stop generation support
  - Error handling

- **`use_completion()`** - Single completion requests

- **Provider Support** (via `llm-client`):
  - OpenAI (gpt-4o, gpt-4o-mini, etc.)
  - Anthropic (claude-3-opus, claude-3-sonnet, etc.)
  - OpenRouter (100+ models)

## Usage Example

```rust
use dioxus::prelude::*;
use dioxus_ai::{use_chat, ChatOptions};

#[component]
fn Chat() -> Element {
    let mut chat = use_chat(ChatOptions {
        provider: "openai".to_string(),
        api_key: "sk-...".to_string(),
        model: "gpt-4o-mini".to_string(),
        ..Default::default()
    });

    rsx! {
        for msg in chat.messages().iter() {
            p { "{msg.content}" }
        }
        button { onclick: move |_| chat.send("Hello!"), "Send" }
    }
}
```

## Files

- `crates/dioxus-ai/Cargo.toml` - Dependencies (Dioxus 0.6, llm-client)
- `crates/dioxus-ai/src/lib.rs` - Module exports
- `crates/dioxus-ai/src/hooks.rs` - use_chat, use_completion
- `crates/dioxus-ai/src/types.rs` - ChatMessage, ChatOptions
- `crates/dioxus-ai/src/error.rs` - Error types
- `crates/dioxus-ai/README.md` - Documentation

## Testing

```bash
cargo build -p dioxus-ai
cargo clippy -p dioxus-ai -- -D warnings
```

Closes #31