### PR TITLE
feat: Audit Logging Integration

### DIFF
--- a/crates/agents/Cargo.toml
+++ b/crates/agents/Cargo.toml
@@ -12,6 +12,7 @@ rust-ai-agents-providers = { path = "../providers" }
 rust-ai-agents-tools = { path = "../tools" }
 rust-ai-agents-monitoring = { path = "../monitoring" }
 rust-ai-agents-encryption = { path = "../encryption", optional = true }
+rust-ai-agents-audit = { path = "../audit", optional = true }
 base64 = { version = "0.22", optional = true }
 tokio = { workspace = true }
 serde = { workspace = true }
@@ -31,3 +32,4 @@ regex = "1.10"
 [features]
 default = []
 encryption = ["rust-ai-agents-encryption", "base64"]
+audit = ["rust-ai-agents-audit"]

--- a/crates/agents/src/audited_executor.rs
+++ b/crates/agents/src/audited_executor.rs
@@ -1,0 +1,425 @@
+//! Audited tool executor wrapper
+//!
+//! Wraps `ToolExecutor` to add audit logging for tool executions and approval decisions.
+
+#[cfg(feature = "audit")]
+use rust_ai_agents_audit::{AuditContext, AuditEvent, AuditLogger, EventKind};
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use rust_ai_agents_core::{AgentId, ToolCall, ToolResult};
+use rust_ai_agents_tools::ToolRegistry;
+
+use crate::approvals::ApprovalHandler;
+use crate::executor::{ExecutionOutcome, ToolExecutor};
+
+/// Audited tool executor that logs all tool executions and approval decisions.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use rust_ai_agents_agents::{AuditedExecutor, ToolExecutor, ExecutorConfig};
+/// use rust_ai_agents_audit::{create_production_logger, MemoryLogger};
+///
+/// let executor = ToolExecutor::new(4);
+/// let logger = Arc::new(MemoryLogger::new());
+/// let audited = AuditedExecutor::new(executor, logger);
+///
+/// // All tool executions are now logged
+/// let results = audited.execute_tools(&calls, &registry, &agent_id).await;
+/// ```
+pub struct AuditedExecutor<H: ApprovalHandler> {
+    inner: ToolExecutor<H>,
+    #[cfg(feature = "audit")]
+    logger: Arc<dyn AuditLogger>,
+    #[cfg(feature = "audit")]
+    context: Option<AuditContext>,
+}
+
+impl<H: ApprovalHandler + 'static> AuditedExecutor<H> {
+    /// Create a new audited executor wrapper.
+    #[cfg(feature = "audit")]
+    pub fn new(executor: ToolExecutor<H>, logger: Arc<dyn AuditLogger>) -> Self {
+        Self {
+            inner: executor,
+            logger,
+            context: None,
+        }
+    }
+
+    /// Create without audit (no-op when feature disabled).
+    #[cfg(not(feature = "audit"))]
+    pub fn new(executor: ToolExecutor<H>) -> Self {
+        Self { inner: executor }
+    }
+
+    /// Set the audit context for subsequent executions.
+    #[cfg(feature = "audit")]
+    pub fn with_context(mut self, context: AuditContext) -> Self {
+        self.context = Some(context);
+        self
+    }
+
+    /// Set trace ID for request correlation.
+    #[cfg(feature = "audit")]
+    pub fn with_trace_id(mut self, trace_id: impl Into<String>) -> Self {
+        let ctx = self.context.take().unwrap_or_default();
+        self.context = Some(ctx.with_trace_id(trace_id));
+        self
+    }
+
+    /// Set session ID.
+    #[cfg(feature = "audit")]
+    pub fn with_session_id(mut self, session_id: impl Into<String>) -> Self {
+        let ctx = self.context.take().unwrap_or_default();
+        self.context = Some(ctx.with_session_id(session_id));
+        self
+    }
+
+    /// Set agent ID in context.
+    #[cfg(feature = "audit")]
+    pub fn with_agent_id(mut self, agent_id: impl Into<String>) -> Self {
+        let ctx = self.context.take().unwrap_or_default();
+        self.context = Some(ctx.with_agent_id(agent_id));
+        self
+    }
+
+    /// Execute multiple tools in parallel with approval checks and audit logging.
+    pub async fn execute_tools(
+        &self,
+        tool_calls: &[ToolCall],
+        registry: &Arc<ToolRegistry>,
+        agent_id: &AgentId,
+    ) -> Vec<ToolResult> {
+        #[cfg(feature = "audit")]
+        let start = Instant::now();
+
+        let outcomes = self
+            .inner
+            .execute_tools_with_outcomes(tool_calls, registry, agent_id)
+            .await;
+
+        #[cfg(feature = "audit")]
+        {
+            let duration_ms = start.elapsed().as_millis() as u64;
+            for (call, outcome) in tool_calls.iter().zip(outcomes.iter()) {
+                self.log_tool_execution(call, outcome, duration_ms).await;
+            }
+        }
+
+        outcomes.into_iter().map(|o| o.into_tool_result()).collect()
+    }
+
+    /// Execute tools and return detailed outcomes with audit logging.
+    pub async fn execute_tools_with_outcomes(
+        &self,
+        tool_calls: &[ToolCall],
+        registry: &Arc<ToolRegistry>,
+        agent_id: &AgentId,
+    ) -> Vec<ExecutionOutcome> {
+        #[cfg(feature = "audit")]
+        let start = Instant::now();
+
+        let outcomes = self
+            .inner
+            .execute_tools_with_outcomes(tool_calls, registry, agent_id)
+            .await;
+
+        #[cfg(feature = "audit")]
+        {
+            let duration_ms = start.elapsed().as_millis() as u64;
+            for (call, outcome) in tool_calls.iter().zip(outcomes.iter()) {
+                self.log_tool_execution(call, outcome, duration_ms).await;
+            }
+        }
+
+        outcomes
+    }
+
+    #[cfg(feature = "audit")]
+    async fn log_tool_execution(
+        &self,
+        call: &ToolCall,
+        outcome: &ExecutionOutcome,
+        duration_ms: u64,
+    ) {
+        let (approved, result_json) = match outcome {
+            ExecutionOutcome::Success(result) => {
+                let result_value = serde_json::to_value(result).ok();
+                (true, result_value)
+            }
+            ExecutionOutcome::Denied { reason, .. } => {
+                // Log approval denial
+                self.log_approval_decision(call, false, Some(reason)).await;
+                (false, None)
+            }
+            ExecutionOutcome::Skipped { .. } => {
+                self.log_approval_decision(call, false, Some("skipped"))
+                    .await;
+                (false, None)
+            }
+            ExecutionOutcome::ApprovalError { error, .. } => {
+                self.log_error(&format!("Approval error for {}: {}", call.name, error))
+                    .await;
+                (false, None)
+            }
+        };
+
+        // Log tool call event
+        let mut event = AuditEvent::new(
+            rust_ai_agents_audit::AuditLevel::Info,
+            EventKind::ToolCall {
+                tool_name: call.name.clone(),
+                parameters: call.arguments.clone(),
+                result: result_json,
+                approved,
+                duration_ms: Some(duration_ms),
+            },
+        );
+
+        if let Some(ctx) = &self.context {
+            event = event.with_context(ctx.clone());
+        }
+
+        if let Err(e) = self.logger.log(event).await {
+            tracing::warn!("Failed to log tool execution audit event: {}", e);
+        }
+    }
+
+    #[cfg(feature = "audit")]
+    async fn log_approval_decision(&self, call: &ToolCall, approved: bool, reason: Option<&str>) {
+        let mut event = AuditEvent::new(
+            rust_ai_agents_audit::AuditLevel::Info,
+            EventKind::ApprovalDecision {
+                tool_name: call.name.clone(),
+                approved,
+                reason: reason.map(|r| r.to_string()),
+                approver: "system".to_string(),
+            },
+        );
+
+        if let Some(ctx) = &self.context {
+            event = event.with_context(ctx.clone());
+        }
+
+        if let Err(e) = self.logger.log(event).await {
+            tracing::warn!("Failed to log approval decision audit event: {}", e);
+        }
+    }
+
+    #[cfg(feature = "audit")]
+    async fn log_error(&self, message: &str) {
+        let mut event = AuditEvent::error_event("ToolExecutionError", message);
+
+        if let Some(ctx) = &self.context {
+            event = event.with_context(ctx.clone());
+        }
+
+        if let Err(e) = self.logger.log(event).await {
+            tracing::warn!("Failed to log error audit event: {}", e);
+        }
+    }
+
+    /// Get reference to inner executor.
+    pub fn inner(&self) -> &ToolExecutor<H> {
+        &self.inner
+    }
+
+    /// Get mutable reference to inner executor.
+    pub fn inner_mut(&mut self) -> &mut ToolExecutor<H> {
+        &mut self.inner
+    }
+
+    /// Consume and return inner executor.
+    pub fn into_inner(self) -> ToolExecutor<H> {
+        self.inner
+    }
+}
+
+#[cfg(all(test, feature = "audit"))]
+mod tests {
+    use super::*;
+    use crate::approvals::{ApprovalConfig, ApprovalDecision, TestApprovalHandler};
+    use crate::executor::ExecutorConfig;
+    use rust_ai_agents_audit::MemoryLogger;
+    use rust_ai_agents_core::{Tool, ToolSchema};
+    use rust_ai_agents_tools::ExecutionContext;
+    use serde_json::json;
+    use std::collections::HashMap;
+
+    struct EchoTool;
+
+    #[async_trait::async_trait]
+    impl Tool for EchoTool {
+        fn schema(&self) -> ToolSchema {
+            ToolSchema {
+                name: "echo".to_string(),
+                description: "Echoes input".to_string(),
+                parameters: json!({"type": "object", "properties": {"message": {"type": "string"}}}),
+                dangerous: false,
+                metadata: HashMap::new(),
+            }
+        }
+
+        async fn execute(
+            &self,
+            _ctx: &ExecutionContext,
+            args: serde_json::Value,
+        ) -> Result<serde_json::Value, rust_ai_agents_core::errors::ToolError> {
+            Ok(args)
+        }
+    }
+
+    struct DangerousTool;
+
+    #[async_trait::async_trait]
+    impl Tool for DangerousTool {
+        fn schema(&self) -> ToolSchema {
+            ToolSchema {
+                name: "dangerous".to_string(),
+                description: "A dangerous tool".to_string(),
+                parameters: json!({"type": "object"}),
+                dangerous: true,
+                metadata: HashMap::new(),
+            }
+        }
+
+        async fn execute(
+            &self,
+            _ctx: &ExecutionContext,
+            _args: serde_json::Value,
+        ) -> Result<serde_json::Value, rust_ai_agents_core::errors::ToolError> {
+            Ok(json!({"result": "executed"}))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_audited_executor_logs_tool_calls() {
+        let mut registry = ToolRegistry::new();
+        registry.register(Arc::new(EchoTool));
+        let registry = Arc::new(registry);
+
+        let executor = ToolExecutor::new(4);
+        let logger = Arc::new(MemoryLogger::new());
+        let audited = AuditedExecutor::new(executor, logger.clone())
+            .with_trace_id("test-trace-123")
+            .with_agent_id("test-agent");
+
+        let agent_id = AgentId::new("test");
+        let calls = vec![ToolCall {
+            id: "1".to_string(),
+            name: "echo".to_string(),
+            arguments: json!({"message": "hello"}),
+        }];
+
+        let results = audited.execute_tools(&calls, &registry, &agent_id).await;
+
+        assert_eq!(results.len(), 1);
+        assert!(results[0].success);
+
+        // Check audit logs
+        let events = logger.events().await;
+        assert_eq!(events.len(), 1);
+
+        // Verify tool call event
+        match &events[0].kind {
+            EventKind::ToolCall {
+                tool_name,
+                approved,
+                ..
+            } => {
+                assert_eq!(tool_name, "echo");
+                assert!(approved);
+            }
+            _ => panic!("Expected ToolCall event"),
+        }
+
+        assert_eq!(
+            events[0].context.trace_id,
+            Some("test-trace-123".to_string())
+        );
+        assert_eq!(events[0].context.agent_id, Some("test-agent".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_audited_executor_logs_denials() {
+        let mut registry = ToolRegistry::new();
+        registry.register(Arc::new(DangerousTool));
+        let registry = Arc::new(registry);
+
+        let config = ApprovalConfig::builder()
+            .require_approval_for_dangerous(true)
+            .build();
+
+        let handler = TestApprovalHandler::with_config(config);
+        handler.set_decision("dangerous", ApprovalDecision::denied("Not allowed"));
+
+        let executor = ToolExecutor::with_approval_handler(ExecutorConfig::default(), handler);
+        let logger = Arc::new(MemoryLogger::new());
+        let audited = AuditedExecutor::new(executor, logger.clone());
+
+        let agent_id = AgentId::new("test");
+        let calls = vec![ToolCall {
+            id: "1".to_string(),
+            name: "dangerous".to_string(),
+            arguments: json!({}),
+        }];
+
+        let results = audited.execute_tools(&calls, &registry, &agent_id).await;
+
+        assert_eq!(results.len(), 1);
+        assert!(!results[0].success);
+
+        // Check audit logs - should have approval denial + tool call
+        let events = logger.events().await;
+        assert!(events.len() >= 1);
+
+        // Find the approval decision event
+        let approval_event = events.iter().find(|e| {
+            matches!(
+                &e.kind,
+                EventKind::ApprovalDecision {
+                    approved: false,
+                    ..
+                }
+            )
+        });
+        assert!(approval_event.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_audited_executor_multiple_tools() {
+        let mut registry = ToolRegistry::new();
+        registry.register(Arc::new(EchoTool));
+        let registry = Arc::new(registry);
+
+        let executor = ToolExecutor::new(4);
+        let logger = Arc::new(MemoryLogger::new());
+        let audited = AuditedExecutor::new(executor, logger.clone());
+
+        let agent_id = AgentId::new("test");
+        let calls = vec![
+            ToolCall {
+                id: "1".to_string(),
+                name: "echo".to_string(),
+                arguments: json!({"message": "hello"}),
+            },
+            ToolCall {
+                id: "2".to_string(),
+                name: "echo".to_string(),
+                arguments: json!({"message": "world"}),
+            },
+        ];
+
+        let results = audited.execute_tools(&calls, &registry, &agent_id).await;
+
+        assert_eq!(results.len(), 2);
+        assert!(results[0].success);
+        assert!(results[1].success);
+
+        // Should have 2 tool call events
+        let events = logger.events().await;
+        assert_eq!(events.len(), 2);
+    }
+}

--- a/crates/agents/src/lib.rs
+++ b/crates/agents/src/lib.rs
@@ -29,6 +29,8 @@
 
 pub mod agent_tool;
 pub mod approvals;
+#[cfg(feature = "audit")]
+pub mod audited_executor;
 pub mod checkpoint;
 pub mod discovery;
 pub mod durable;
@@ -53,6 +55,8 @@ pub mod vector_store;
 
 pub use agent_tool::*;
 pub use approvals::*;
+#[cfg(feature = "audit")]
+pub use audited_executor::*;
 pub use checkpoint::*;
 pub use discovery::*;
 pub use durable::*;

--- a/crates/audit/src/types.rs
+++ b/crates/audit/src/types.rs
@@ -334,6 +334,21 @@ impl AuditEvent {
         })
     }
 
+    /// Convenience: create an LLM response event.
+    pub fn llm_response(
+        provider: impl Into<String>,
+        model: impl Into<String>,
+        tool_calls_count: usize,
+        finish_reason: Option<impl Into<String>>,
+    ) -> Self {
+        Self::info(EventKind::LlmResponse {
+            provider: provider.into(),
+            model: model.into(),
+            finish_reason: finish_reason.map(|r| r.into()),
+            tool_calls_count,
+        })
+    }
+
     /// Convenience: create an error event.
     pub fn error_event(error_type: impl Into<String>, message: impl Into<String>) -> Self {
         Self::error(EventKind::Error {

--- a/crates/dashboard/Cargo.toml
+++ b/crates/dashboard/Cargo.toml
@@ -26,6 +26,9 @@ rust-ai-agents-monitoring = { path = "../monitoring" }
 # Agents crate for real data integration
 rust-ai-agents-agents = { path = "../agents", optional = true }
 
+# Audit logging
+rust-ai-agents-audit = { path = "../audit", optional = true }
+
 # Providers crate for LLM streaming
 rust-ai-agents-providers = { path = "../providers", optional = true }
 
@@ -58,3 +61,4 @@ metrics-exporter-prometheus = "0.15"
 default = []
 agents = ["rust-ai-agents-agents"]
 streaming = ["rust-ai-agents-providers", "rust-ai-agents-core"]
+audit = ["rust-ai-agents-audit"]

--- a/crates/dashboard/src/audit.rs
+++ b/crates/dashboard/src/audit.rs
@@ -1,0 +1,360 @@
+//! Audit logging middleware and API endpoints for the dashboard.
+//!
+//! Provides:
+//! - Request/response audit logging middleware
+//! - API endpoints for querying audit logs
+//! - Real-time audit event streaming via WebSocket
+
+use axum::{
+    body::Body,
+    extract::{Query, State},
+    http::Request,
+    middleware::Next,
+    response::{IntoResponse, Json, Response},
+    routing::get,
+    Router,
+};
+use rust_ai_agents_audit::{AuditContext, AuditEvent, AuditLogger, EventKind, MemoryLogger};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::time::Instant;
+
+/// State for audit endpoints
+pub struct AuditState {
+    /// The audit logger (using MemoryLogger for queryable in-memory storage)
+    pub logger: Arc<MemoryLogger>,
+}
+
+impl AuditState {
+    /// Create new audit state with a memory logger for dashboard queries.
+    pub fn new() -> Self {
+        Self {
+            logger: Arc::new(MemoryLogger::new()),
+        }
+    }
+
+    /// Create with an existing memory logger.
+    pub fn with_logger(logger: Arc<MemoryLogger>) -> Self {
+        Self { logger }
+    }
+}
+
+impl Default for AuditState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Query parameters for listing audit events
+#[derive(Debug, Deserialize)]
+pub struct AuditQuery {
+    /// Filter by event type
+    pub event_type: Option<String>,
+    /// Filter by trace ID
+    pub trace_id: Option<String>,
+    /// Filter by session ID
+    pub session_id: Option<String>,
+    /// Filter by agent ID
+    pub agent_id: Option<String>,
+    /// Maximum number of events to return
+    pub limit: Option<usize>,
+    /// Offset for pagination
+    pub offset: Option<usize>,
+}
+
+/// Audit event response for API
+#[derive(Debug, Serialize)]
+pub struct AuditEventResponse {
+    pub id: String,
+    pub timestamp: String,
+    pub level: String,
+    pub event_type: String,
+    pub details: serde_json::Value,
+    pub context: AuditContextResponse,
+}
+
+/// Audit context response
+#[derive(Debug, Serialize)]
+pub struct AuditContextResponse {
+    pub trace_id: Option<String>,
+    pub session_id: Option<String>,
+    pub agent_id: Option<String>,
+    pub user_id: Option<String>,
+}
+
+impl From<&AuditEvent> for AuditEventResponse {
+    fn from(event: &AuditEvent) -> Self {
+        let event_type = match &event.kind {
+            EventKind::ToolCall { .. } => "tool_call",
+            EventKind::LlmRequest { .. } => "llm_request",
+            EventKind::LlmResponse { .. } => "llm_response",
+            EventKind::AgentLifecycle { .. } => "agent_lifecycle",
+            EventKind::ApprovalDecision { .. } => "approval_decision",
+            EventKind::Error { .. } => "error",
+            EventKind::Security { .. } => "security",
+            EventKind::Custom { .. } => "custom",
+        };
+
+        let details = serde_json::to_value(&event.kind).unwrap_or_default();
+
+        Self {
+            id: event.id.to_string(),
+            timestamp: event.timestamp.to_rfc3339(),
+            level: format!("{:?}", event.level),
+            event_type: event_type.to_string(),
+            details,
+            context: AuditContextResponse {
+                trace_id: event.context.trace_id.clone(),
+                session_id: event.context.session_id.clone(),
+                agent_id: event.context.agent_id.clone(),
+                user_id: event.context.user_id.clone(),
+            },
+        }
+    }
+}
+
+/// List audit events with optional filtering
+pub async fn list_audit_events(
+    State(state): State<Arc<AuditState>>,
+    Query(query): Query<AuditQuery>,
+) -> impl IntoResponse {
+    let events = state.logger.events().await;
+
+    let filtered: Vec<_> = events
+        .iter()
+        .filter(|e| {
+            // Filter by event type
+            if let Some(ref event_type) = query.event_type {
+                let matches = match (&e.kind, event_type.as_str()) {
+                    (EventKind::ToolCall { .. }, "tool_call") => true,
+                    (EventKind::LlmRequest { .. }, "llm_request") => true,
+                    (EventKind::LlmResponse { .. }, "llm_response") => true,
+                    (EventKind::AgentLifecycle { .. }, "agent_lifecycle") => true,
+                    (EventKind::ApprovalDecision { .. }, "approval_decision") => true,
+                    (EventKind::Error { .. }, "error") => true,
+                    (EventKind::Security { .. }, "security") => true,
+                    (EventKind::Custom { .. }, "custom") => true,
+                    _ => false,
+                };
+                if !matches {
+                    return false;
+                }
+            }
+
+            // Filter by trace ID
+            if let Some(ref trace_id) = query.trace_id {
+                if e.context.trace_id.as_ref() != Some(trace_id) {
+                    return false;
+                }
+            }
+
+            // Filter by session ID
+            if let Some(ref session_id) = query.session_id {
+                if e.context.session_id.as_ref() != Some(session_id) {
+                    return false;
+                }
+            }
+
+            // Filter by agent ID
+            if let Some(ref agent_id) = query.agent_id {
+                if e.context.agent_id.as_ref() != Some(agent_id) {
+                    return false;
+                }
+            }
+
+            true
+        })
+        .collect();
+
+    // Apply pagination
+    let offset = query.offset.unwrap_or(0);
+    let limit = query.limit.unwrap_or(100).min(1000);
+
+    let paginated: Vec<AuditEventResponse> = filtered
+        .into_iter()
+        .skip(offset)
+        .take(limit)
+        .map(|e| e.into())
+        .collect();
+
+    Json(paginated)
+}
+
+/// Get audit statistics
+pub async fn get_audit_stats(State(state): State<Arc<AuditState>>) -> impl IntoResponse {
+    let events = state.logger.events().await;
+
+    let mut stats = AuditStats::default();
+
+    for event in events.iter() {
+        stats.total += 1;
+        match &event.kind {
+            EventKind::ToolCall { .. } => stats.tool_calls += 1,
+            EventKind::LlmRequest { .. } => stats.llm_requests += 1,
+            EventKind::LlmResponse { .. } => stats.llm_responses += 1,
+            EventKind::AgentLifecycle { .. } => stats.lifecycle_events += 1,
+            EventKind::ApprovalDecision { approved, .. } => {
+                if *approved {
+                    stats.approvals += 1;
+                } else {
+                    stats.denials += 1;
+                }
+            }
+            EventKind::Error { .. } => stats.errors += 1,
+            EventKind::Security { .. } => stats.security_events += 1,
+            EventKind::Custom { .. } => stats.custom_events += 1,
+        }
+    }
+
+    Json(stats)
+}
+
+/// Audit statistics response
+#[derive(Debug, Default, Serialize)]
+pub struct AuditStats {
+    pub total: usize,
+    pub tool_calls: usize,
+    pub llm_requests: usize,
+    pub llm_responses: usize,
+    pub lifecycle_events: usize,
+    pub approvals: usize,
+    pub denials: usize,
+    pub errors: usize,
+    pub security_events: usize,
+    pub custom_events: usize,
+}
+
+/// Middleware that logs HTTP requests to the audit log.
+pub async fn audit_middleware(
+    State(state): State<Arc<AuditState>>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    let start = Instant::now();
+    let method = request.method().clone();
+    let uri = request.uri().clone();
+    let path = uri.path().to_string();
+
+    // Skip audit logging for audit endpoints themselves to avoid recursion
+    if path.starts_with("/api/audit") {
+        return next.run(request).await;
+    }
+
+    // Extract trace ID from headers if present
+    let trace_id = request
+        .headers()
+        .get("x-trace-id")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+
+    let response = next.run(request).await;
+
+    let duration_ms = start.elapsed().as_millis() as u64;
+    let status = response.status().as_u16();
+
+    // Log the request
+    let mut ctx = AuditContext::default();
+    if let Some(tid) = trace_id {
+        ctx = ctx.with_trace_id(tid);
+    }
+    ctx = ctx
+        .with_metadata("method", serde_json::json!(method.as_str()))
+        .with_metadata("path", serde_json::json!(path))
+        .with_metadata("status", serde_json::json!(status))
+        .with_metadata("duration_ms", serde_json::json!(duration_ms));
+
+    let event = AuditEvent::new(
+        rust_ai_agents_audit::AuditLevel::Info,
+        EventKind::Custom {
+            name: "http_request".to_string(),
+            payload: serde_json::json!({
+                "method": method.as_str(),
+                "path": path,
+                "status": status,
+                "duration_ms": duration_ms,
+            }),
+        },
+    )
+    .with_context(ctx);
+
+    // Log asynchronously to not block response
+    let logger = state.logger.clone();
+    tokio::spawn(async move {
+        if let Err(e) = logger.log(event).await {
+            tracing::warn!("Failed to log HTTP request audit event: {}", e);
+        }
+    });
+
+    response
+}
+
+/// Create router with audit endpoints
+pub fn audit_routes() -> Router<Arc<AuditState>> {
+    Router::new()
+        .route("/api/audit/events", get(list_audit_events))
+        .route("/api/audit/stats", get(get_audit_stats))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_audit_state_creation() {
+        let state = AuditState::new();
+        let events = state.logger.events().await;
+        assert!(events.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_audit_event_logging() {
+        let state = AuditState::new();
+
+        let event = AuditEvent::tool_call("test_tool", serde_json::json!({}), true);
+        state.logger.log(event).await.unwrap();
+
+        let events = state.logger.events().await;
+        assert_eq!(events.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_audit_stats() {
+        let state = Arc::new(AuditState::new());
+
+        // Log various events
+        state
+            .logger
+            .log(AuditEvent::tool_call("tool1", serde_json::json!({}), true))
+            .await
+            .unwrap();
+        state
+            .logger
+            .log(AuditEvent::llm_request("anthropic", "claude-3", false))
+            .await
+            .unwrap();
+        state
+            .logger
+            .log(AuditEvent::error_event("TestError", "test message"))
+            .await
+            .unwrap();
+
+        let events = state.logger.events().await;
+        assert_eq!(events.len(), 3);
+    }
+
+    #[test]
+    fn test_audit_event_response_conversion() {
+        let event = AuditEvent::tool_call("my_tool", serde_json::json!({"key": "value"}), true)
+            .with_context(
+                AuditContext::default()
+                    .with_trace_id("trace-123")
+                    .with_agent_id("agent-1"),
+            );
+
+        let response: AuditEventResponse = (&event).into();
+
+        assert_eq!(response.event_type, "tool_call");
+        assert_eq!(response.context.trace_id, Some("trace-123".to_string()));
+        assert_eq!(response.context.agent_id, Some("agent-1".to_string()));
+    }
+}

--- a/crates/dashboard/src/lib.rs
+++ b/crates/dashboard/src/lib.rs
@@ -36,6 +36,9 @@ mod websocket;
 #[cfg(feature = "agents")]
 pub mod integration;
 
+#[cfg(feature = "audit")]
+pub mod audit;
+
 #[cfg(feature = "streaming")]
 pub mod streaming;
 
@@ -48,6 +51,11 @@ pub use state::{
 #[cfg(feature = "agents")]
 pub use integration::{
     add_demo_data, AgentBridge, DashboardBridge, SessionBridge, TrajectoryBridge,
+};
+
+#[cfg(feature = "audit")]
+pub use audit::{
+    audit_middleware, audit_routes, AuditEventResponse, AuditQuery, AuditState, AuditStats,
 };
 
 #[cfg(feature = "streaming")]

--- a/crates/providers/Cargo.toml
+++ b/crates/providers/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 [dependencies]
 rust-ai-agents-core = { path = "../core" }
 rust-ai-agents-monitoring = { path = "../monitoring" }
+rust-ai-agents-audit = { path = "../audit", optional = true }
 tokio = { workspace = true }
 reqwest = { version = "0.12", features = ["json", "rustls-tls", "stream"], default-features = false }
 serde = { workspace = true }
@@ -28,3 +29,7 @@ regex = "1.10"
 uuid = { workspace = true }
 chrono = { workspace = true }
 rand = { workspace = true }
+
+[features]
+default = []
+audit = ["rust-ai-agents-audit"]

--- a/crates/providers/src/audited.rs
+++ b/crates/providers/src/audited.rs
@@ -1,0 +1,304 @@
+//! Audited LLM backend wrapper
+//!
+//! Wraps any `LLMBackend` to add audit logging for all LLM requests and responses.
+
+#[cfg(feature = "audit")]
+use rust_ai_agents_audit::{AuditContext, AuditEvent, AuditLogger};
+
+use crate::{InferenceOutput, LLMBackend, ModelInfo, StreamResponse, TokenUsage};
+use async_trait::async_trait;
+use rust_ai_agents_core::{errors::LLMError, LLMMessage, ToolSchema};
+use std::sync::Arc;
+
+#[cfg(feature = "audit")]
+use std::time::Instant;
+
+/// Wrapper that adds audit logging to any LLM backend.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use rust_ai_agents_providers::{AnthropicProvider, AuditedBackend};
+/// use rust_ai_agents_audit::{JsonFileLogger, create_production_logger};
+///
+/// let claude = AnthropicProvider::claude_35_sonnet(api_key);
+/// let logger = create_production_logger("/var/log/audit.jsonl").await?;
+/// let audited = AuditedBackend::new(claude, Arc::new(logger));
+///
+/// // All LLM calls are now logged
+/// let output = audited.infer(&messages, &tools, 0.7).await?;
+/// ```
+#[derive(Clone)]
+pub struct AuditedBackend<B: LLMBackend> {
+    inner: B,
+    #[cfg(feature = "audit")]
+    logger: Arc<dyn AuditLogger>,
+    #[cfg(feature = "audit")]
+    context: Option<AuditContext>,
+}
+
+impl<B: LLMBackend> AuditedBackend<B> {
+    /// Create a new audited backend wrapper.
+    #[cfg(feature = "audit")]
+    pub fn new(backend: B, logger: Arc<dyn AuditLogger>) -> Self {
+        Self {
+            inner: backend,
+            logger,
+            context: None,
+        }
+    }
+
+    /// Create without audit (no-op when feature disabled).
+    #[cfg(not(feature = "audit"))]
+    pub fn new(backend: B) -> Self {
+        Self { inner: backend }
+    }
+
+    /// Set the audit context for subsequent calls.
+    #[cfg(feature = "audit")]
+    pub fn with_context(mut self, context: AuditContext) -> Self {
+        self.context = Some(context);
+        self
+    }
+
+    /// Set trace ID for request correlation.
+    #[cfg(feature = "audit")]
+    pub fn with_trace_id(mut self, trace_id: impl Into<String>) -> Self {
+        let ctx = self.context.take().unwrap_or_default();
+        self.context = Some(ctx.with_trace_id(trace_id));
+        self
+    }
+
+    /// Set session ID.
+    #[cfg(feature = "audit")]
+    pub fn with_session_id(mut self, session_id: impl Into<String>) -> Self {
+        let ctx = self.context.take().unwrap_or_default();
+        self.context = Some(ctx.with_session_id(session_id));
+        self
+    }
+
+    /// Set agent ID.
+    #[cfg(feature = "audit")]
+    pub fn with_agent_id(mut self, agent_id: impl Into<String>) -> Self {
+        let ctx = self.context.take().unwrap_or_default();
+        self.context = Some(ctx.with_agent_id(agent_id));
+        self
+    }
+
+    /// Get reference to inner backend.
+    pub fn inner(&self) -> &B {
+        &self.inner
+    }
+
+    /// Get mutable reference to inner backend.
+    pub fn inner_mut(&mut self) -> &mut B {
+        &mut self.inner
+    }
+
+    /// Consume and return inner backend.
+    pub fn into_inner(self) -> B {
+        self.inner
+    }
+
+    #[cfg(feature = "audit")]
+    async fn log_request(&self, model: &str, provider: &str, streaming: bool) {
+        let mut event = AuditEvent::llm_request(provider, model, streaming);
+        if let Some(ctx) = &self.context {
+            event = event.with_context(ctx.clone());
+        }
+        if let Err(e) = self.logger.log(event).await {
+            tracing::warn!("Failed to log LLM request audit event: {}", e);
+        }
+    }
+
+    #[cfg(feature = "audit")]
+    async fn log_response(
+        &self,
+        model: &str,
+        provider: &str,
+        usage: &TokenUsage,
+        tool_call_count: usize,
+        duration_ms: u64,
+        finish_reason: Option<&str>,
+    ) {
+        let mut event = AuditEvent::llm_response(provider, model, tool_call_count, finish_reason);
+
+        // Add context with token usage and duration metadata
+        let mut ctx = self.context.clone().unwrap_or_default();
+        ctx = ctx
+            .with_metadata("duration_ms", serde_json::json!(duration_ms))
+            .with_metadata("input_tokens", serde_json::json!(usage.prompt_tokens))
+            .with_metadata("output_tokens", serde_json::json!(usage.completion_tokens))
+            .with_metadata("total_tokens", serde_json::json!(usage.total_tokens));
+
+        event = event.with_context(ctx);
+
+        if let Err(e) = self.logger.log(event).await {
+            tracing::warn!("Failed to log LLM response audit event: {}", e);
+        }
+    }
+
+    #[cfg(feature = "audit")]
+    async fn log_error(&self, error: &LLMError) {
+        let mut event = AuditEvent::error_event("LLMError", &error.to_string());
+        if let Some(ctx) = &self.context {
+            event = event.with_context(ctx.clone());
+        }
+        if let Err(e) = self.logger.log(event).await {
+            tracing::warn!("Failed to log LLM error audit event: {}", e);
+        }
+    }
+}
+
+#[async_trait]
+impl<B: LLMBackend + 'static> LLMBackend for AuditedBackend<B> {
+    async fn infer(
+        &self,
+        messages: &[LLMMessage],
+        tools: &[ToolSchema],
+        temperature: f32,
+    ) -> Result<InferenceOutput, LLMError> {
+        let info = self.inner.model_info();
+
+        #[cfg(feature = "audit")]
+        let start = Instant::now();
+
+        #[cfg(feature = "audit")]
+        self.log_request(&info.model, &info.provider, false).await;
+
+        let result = self.inner.infer(messages, tools, temperature).await;
+
+        #[cfg(feature = "audit")]
+        {
+            let duration_ms = start.elapsed().as_millis() as u64;
+            match &result {
+                Ok(output) => {
+                    let tool_count = output.tool_calls.as_ref().map(|t| t.len()).unwrap_or(0);
+                    self.log_response(
+                        &info.model,
+                        &info.provider,
+                        &output.token_usage,
+                        tool_count,
+                        duration_ms,
+                        Some("stop"),
+                    )
+                    .await;
+                }
+                Err(e) => {
+                    self.log_error(e).await;
+                }
+            }
+        }
+
+        result
+    }
+
+    async fn infer_stream(
+        &self,
+        messages: &[LLMMessage],
+        tools: &[ToolSchema],
+        temperature: f32,
+    ) -> Result<StreamResponse, LLMError> {
+        let info = self.inner.model_info();
+
+        #[cfg(feature = "audit")]
+        self.log_request(&info.model, &info.provider, true).await;
+
+        // For streaming, we log the request but can't easily log the response
+        // until the stream is consumed. The caller should handle final logging.
+        self.inner.infer_stream(messages, tools, temperature).await
+    }
+
+    async fn embed(&self, text: &str) -> Result<Vec<f32>, LLMError> {
+        self.inner.embed(text).await
+    }
+
+    fn model_info(&self) -> ModelInfo {
+        self.inner.model_info()
+    }
+
+    fn supports_function_calling(&self) -> bool {
+        self.inner.supports_function_calling()
+    }
+
+    fn supports_streaming(&self) -> bool {
+        self.inner.supports_streaming()
+    }
+}
+
+#[cfg(all(test, feature = "audit"))]
+mod tests {
+    use super::*;
+    use crate::mock::{MockBackend, MockResponse};
+    use rust_ai_agents_audit::MemoryLogger;
+    use rust_ai_agents_core::MessageRole;
+
+    #[tokio::test]
+    async fn test_audited_backend_logs_request_and_response() {
+        let mock = MockBackend::new().with_response(MockResponse::text("Hello!"));
+        let logger = Arc::new(MemoryLogger::new());
+        let audited = AuditedBackend::new(mock, logger.clone())
+            .with_trace_id("test-trace-123")
+            .with_agent_id("test-agent");
+
+        let messages = vec![LLMMessage {
+            role: MessageRole::User,
+            content: "Hi".to_string(),
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+        }];
+
+        let result = audited.infer(&messages, &[], 0.7).await;
+        assert!(result.is_ok());
+
+        // Check audit logs
+        let events = logger.events().await;
+        assert_eq!(events.len(), 2); // request + response
+
+        // Verify request event
+        assert!(matches!(
+            &events[0].kind,
+            rust_ai_agents_audit::EventKind::LlmRequest { .. }
+        ));
+        assert_eq!(
+            events[0].context.trace_id,
+            Some("test-trace-123".to_string())
+        );
+        assert_eq!(events[0].context.agent_id, Some("test-agent".to_string()));
+
+        // Verify response event
+        assert!(matches!(
+            &events[1].kind,
+            rust_ai_agents_audit::EventKind::LlmResponse { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_audited_backend_logs_errors() {
+        let mock = MockBackend::new().with_response(MockResponse::error("API Error"));
+        let logger = Arc::new(MemoryLogger::new());
+        let audited = AuditedBackend::new(mock, logger.clone());
+
+        let messages = vec![LLMMessage {
+            role: MessageRole::User,
+            content: "Hi".to_string(),
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+        }];
+
+        let result = audited.infer(&messages, &[], 0.7).await;
+        assert!(result.is_err());
+
+        // Check audit logs
+        let events = logger.events().await;
+        assert_eq!(events.len(), 2); // request + error
+
+        // Verify error event
+        assert!(matches!(
+            &events[1].kind,
+            rust_ai_agents_audit::EventKind::Error { .. }
+        ));
+    }
+}

--- a/crates/providers/src/lib.rs
+++ b/crates/providers/src/lib.rs
@@ -30,6 +30,8 @@
 //! ```
 
 pub mod anthropic;
+#[cfg(feature = "audit")]
+pub mod audited;
 pub mod backend;
 pub mod instrumented;
 pub mod mock;
@@ -41,6 +43,8 @@ pub mod router;
 pub mod structured;
 
 pub use anthropic::{AnthropicProvider, ClaudeModel};
+#[cfg(feature = "audit")]
+pub use audited::AuditedBackend;
 pub use backend::{
     InferenceOutput, LLMBackend, ModelInfo, RateLimiter, StreamEvent, StreamResponse, TokenUsage,
 };


### PR DESCRIPTION
## Summary

Integrates the existing audit crate into the production code path, enabling comprehensive audit logging for LLM operations, tool execution, and HTTP requests.

## Changes

### Providers Crate (`audit` feature)
- **AuditedBackend<B>** wrapper for any LLMBackend
  - Logs `LlmRequest` events before inference
  - Logs `LlmResponse` events with token usage after inference
  - Logs `Error` events on failures
  - Supports context propagation (trace_id, session_id, agent_id)

### Agents Crate (`audit` feature)
- **AuditedExecutor<H>** wrapper for ToolExecutor
  - Logs `ToolCall` events with parameters and results
  - Logs `ApprovalDecision` events for denied/skipped tools
  - Logs `Error` events for approval errors
  - Duration tracking for tool executions

### Dashboard Crate (`audit` feature)
- **REST API Endpoints**
  - `GET /api/audit/events` - List events with filtering (event_type, trace_id, session_id, agent_id, pagination)
  - `GET /api/audit/stats` - Aggregated statistics by event type
- **HTTP Audit Middleware** - Logs all HTTP requests with method, path, status, duration
- Uses MemoryLogger for queryable in-memory storage

### Audit Types Enhancement
- Added `AuditEvent::llm_response()` convenience constructor

## Testing
- **Providers**: 2 new tests (request/response logging, error logging)
- **Agents**: 3 new tests (tool calls, denials, multiple tools)
- **Dashboard**: 4 new tests (state, logging, stats, conversion)
- All 9 new tests passing

## Usage

```rust
// Wrap any LLM backend with audit logging
use rust_ai_agents_providers::AuditedBackend;
use rust_ai_agents_audit::MemoryLogger;

let backend = AnthropicProvider::claude_35_sonnet(api_key);
let logger = Arc::new(MemoryLogger::new());
let audited = AuditedBackend::new(backend, logger)
    .with_trace_id("req-123")
    .with_agent_id("research-agent");

// All LLM calls are now logged
let output = audited.infer(&messages, &tools, 0.7).await?;
```

## Feature Flags

All integrations are opt-in via feature flags:
- `rust-ai-agents-providers/audit`
- `rust-ai-agents-agents/audit`
- `rust-ai-agents-dashboard/audit`