### PR TITLE
feat: add Cloudflare Workers support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "crates/github-ops",
     "crates/llm-client",
     "crates/fastly",
+    "crates/cloudflare",
     "crates/leptos-ai",
     "crates/dioxus-ai",
     "crates/studio",

--- a/crates/cloudflare/Cargo.toml
+++ b/crates/cloudflare/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "rust-ai-agents-cloudflare"
+version = "0.1.0"
+edition = "2021"
+description = "Cloudflare Workers support for Rust AI Agents"
+license = "Apache-2.0"
+authors = ["Ronaldo Lima"]
+repository = "https://github.com/limaronaldo/rust-ai-agents"
+keywords = ["ai", "agents", "cloudflare", "workers", "wasm"]
+categories = ["wasm", "web-programming"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+# Cloudflare Workers SDK
+worker = "0.4"
+
+# Shared LLM client logic
+rust-ai-agents-llm-client = { path = "../llm-client" }
+
+# Serialization
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+# WASM bindings
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+js-sys = "0.3"
+
+# Async
+futures = "0.3"
+
+# Error handling
+thiserror = "1.0"
+
+# UUID for request IDs (with JS feature for WASM)
+uuid = { version = "1.8", features = ["v4", "serde", "js"] }
+
+# Random for WASM
+getrandom = { version = "0.2", features = ["js"] }
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"

--- a/crates/cloudflare/src/agent.rs
+++ b/crates/cloudflare/src/agent.rs
@@ -1,0 +1,243 @@
+//! Cloudflare Workers AI Agent
+
+use crate::config::CloudflareConfig;
+use crate::error::{CloudflareError, Result};
+use crate::http::CloudflareHttpClient;
+use crate::kv::{KvStore, SessionMetadata};
+use rust_ai_agents_llm_client::{Message, RequestBuilder, Role};
+
+/// AI Agent for Cloudflare Workers
+///
+/// Provides chat functionality with optional KV-based conversation persistence.
+pub struct CloudflareAgent {
+    config: CloudflareConfig,
+    messages: Vec<Message>,
+    kv: Option<KvStore>,
+}
+
+impl CloudflareAgent {
+    /// Create a new Cloudflare agent with the given configuration
+    pub fn new(config: CloudflareConfig) -> Self {
+        let mut messages = Vec::new();
+
+        // Add system prompt if configured
+        if let Some(ref prompt) = config.system_prompt {
+            messages.push(Message::system(prompt));
+        }
+
+        Self {
+            config,
+            messages,
+            kv: None,
+        }
+    }
+
+    /// Attach a KV store for conversation persistence
+    pub fn with_kv(mut self, kv: KvStore) -> Self {
+        self.kv = Some(kv);
+        self
+    }
+
+    /// Send a message and get a response (non-streaming)
+    pub async fn chat(&mut self, message: &str) -> Result<AgentResponse> {
+        // Add user message
+        self.messages.push(Message::user(message));
+
+        // Build and send request
+        let request = self.build_request(false)?;
+        let response = CloudflareHttpClient::execute(request).await?;
+
+        // Add assistant response to history
+        self.messages.push(Message::assistant(&response.content));
+
+        Ok(AgentResponse {
+            content: response.content,
+            tool_calls: if response.tool_calls.is_empty() {
+                None
+            } else {
+                Some(response.tool_calls)
+            },
+            usage: response.usage.map(|u| AgentUsage {
+                prompt_tokens: u.prompt_tokens,
+                completion_tokens: u.completion_tokens,
+                total_tokens: u.total_tokens,
+            }),
+        })
+    }
+
+    /// Send a message with session persistence
+    pub async fn chat_with_session(
+        &mut self,
+        session_id: &str,
+        message: &str,
+    ) -> Result<AgentResponse> {
+        // Check KV is configured
+        if self.kv.is_none() {
+            return Err(CloudflareError::ConfigError(
+                "KV store not configured".to_string(),
+            ));
+        }
+
+        // Load existing conversation
+        let history = self
+            .kv
+            .as_ref()
+            .unwrap()
+            .get_conversation(session_id)
+            .await?;
+
+        if !history.is_empty() {
+            // Keep system prompt if exists, then add history
+            let system_prompt = self.messages.first().cloned();
+            self.messages.clear();
+            if let Some(prompt) = system_prompt {
+                if matches!(prompt.role, Role::System) {
+                    self.messages.push(prompt);
+                }
+            }
+            self.messages.extend(history);
+        }
+
+        // Chat normally
+        let response = self.chat(message).await?;
+
+        // Save updated conversation
+        let kv = self.kv.as_ref().unwrap();
+        kv.save_conversation(session_id, &self.messages).await?;
+
+        // Update metadata
+        let mut metadata = kv
+            .get_metadata(session_id)
+            .await?
+            .unwrap_or_else(|| SessionMetadata::new(session_id));
+
+        if let Some(usage) = &response.usage {
+            metadata.add_tokens(usage.total_tokens);
+        }
+        metadata.increment_messages();
+        kv.save_metadata(session_id, &metadata).await?;
+
+        Ok(response)
+    }
+
+    /// Send a message and get a streaming response
+    pub async fn chat_stream(&mut self, message: &str) -> Result<worker::Response> {
+        // Add user message
+        self.messages.push(Message::user(message));
+
+        // Build and send streaming request
+        let request = self.build_request(true)?;
+        let response = CloudflareHttpClient::execute_stream(request).await?;
+
+        Ok(response)
+    }
+
+    /// Get current conversation history
+    pub fn history(&self) -> &[Message] {
+        &self.messages
+    }
+
+    /// Clear conversation history (keeps system prompt)
+    pub fn clear_history(&mut self) {
+        let system_prompt = self.messages.first().cloned();
+        self.messages.clear();
+        if let Some(prompt) = system_prompt {
+            if matches!(prompt.role, Role::System) {
+                self.messages.push(prompt);
+            }
+        }
+    }
+
+    /// Build an HTTP request for the LLM API
+    fn build_request(&self, stream: bool) -> Result<rust_ai_agents_llm_client::HttpRequest> {
+        let mut builder = RequestBuilder::new(self.config.provider)
+            .api_key(&self.config.api_key)
+            .model(&self.config.model)
+            .temperature(self.config.temperature)
+            .stream(stream)
+            .messages(&self.messages);
+
+        if let Some(max_tokens) = self.config.max_tokens {
+            builder = builder.max_tokens(max_tokens);
+        }
+
+        builder
+            .build()
+            .map_err(|e| CloudflareError::ConfigError(e.to_string()))
+    }
+}
+
+/// Response from the agent
+#[derive(Debug, Clone)]
+pub struct AgentResponse {
+    /// Generated content
+    pub content: String,
+    /// Tool calls (if any)
+    pub tool_calls: Option<Vec<rust_ai_agents_llm_client::ToolCall>>,
+    /// Token usage
+    pub usage: Option<AgentUsage>,
+}
+
+/// Token usage information
+#[derive(Debug, Clone)]
+pub struct AgentUsage {
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub total_tokens: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rust_ai_agents_llm_client::Provider;
+
+    #[test]
+    fn test_agent_creation() {
+        let config = CloudflareConfig::builder()
+            .provider(Provider::Anthropic)
+            .api_key("test-key")
+            .model("claude-3")
+            .system_prompt("You are helpful")
+            .build();
+
+        let agent = CloudflareAgent::new(config);
+
+        assert_eq!(agent.messages.len(), 1);
+        assert!(matches!(agent.messages[0].role, Role::System));
+        assert_eq!(agent.messages[0].content, "You are helpful");
+    }
+
+    #[test]
+    fn test_clear_history() {
+        let config = CloudflareConfig::builder()
+            .provider(Provider::OpenAI)
+            .api_key("test")
+            .system_prompt("System")
+            .build();
+
+        let mut agent = CloudflareAgent::new(config);
+
+        // Simulate adding messages
+        agent.messages.push(Message::user("Hello"));
+        agent.messages.push(Message::assistant("Hi"));
+
+        assert_eq!(agent.messages.len(), 3);
+
+        agent.clear_history();
+
+        // Should only have system prompt
+        assert_eq!(agent.messages.len(), 1);
+        assert!(matches!(agent.messages[0].role, Role::System));
+    }
+
+    #[test]
+    fn test_agent_without_system_prompt() {
+        let config = CloudflareConfig::builder()
+            .provider(Provider::OpenAI)
+            .api_key("test")
+            .build();
+
+        let agent = CloudflareAgent::new(config);
+        assert!(agent.messages.is_empty());
+    }
+}

--- a/crates/cloudflare/src/config.rs
+++ b/crates/cloudflare/src/config.rs
@@ -1,0 +1,147 @@
+//! Configuration for Cloudflare Workers agent
+
+use rust_ai_agents_llm_client::Provider;
+
+/// Configuration for the Cloudflare agent
+#[derive(Debug, Clone)]
+pub struct CloudflareConfig {
+    /// LLM provider (OpenAI, Anthropic, OpenRouter)
+    pub provider: Provider,
+
+    /// API key for the provider
+    pub api_key: String,
+
+    /// Model identifier (e.g., "gpt-4", "claude-3-5-sonnet-20241022")
+    pub model: String,
+
+    /// System prompt for the agent
+    pub system_prompt: Option<String>,
+
+    /// Temperature for response generation (0.0 - 2.0)
+    pub temperature: f32,
+
+    /// Maximum tokens in response
+    pub max_tokens: Option<u32>,
+
+    /// Whether to use streaming responses
+    pub stream: bool,
+}
+
+impl Default for CloudflareConfig {
+    fn default() -> Self {
+        Self {
+            provider: Provider::OpenAI,
+            api_key: String::new(),
+            model: "gpt-4".to_string(),
+            system_prompt: None,
+            temperature: 0.7,
+            max_tokens: None,
+            stream: false,
+        }
+    }
+}
+
+impl CloudflareConfig {
+    /// Create a new configuration builder
+    pub fn builder() -> CloudflareConfigBuilder {
+        CloudflareConfigBuilder::default()
+    }
+}
+
+/// Builder for CloudflareConfig
+#[derive(Debug, Default)]
+pub struct CloudflareConfigBuilder {
+    provider: Option<Provider>,
+    api_key: Option<String>,
+    model: Option<String>,
+    system_prompt: Option<String>,
+    temperature: Option<f32>,
+    max_tokens: Option<u32>,
+    stream: Option<bool>,
+}
+
+impl CloudflareConfigBuilder {
+    /// Set the LLM provider
+    pub fn provider(mut self, provider: Provider) -> Self {
+        self.provider = Some(provider);
+        self
+    }
+
+    /// Set the API key
+    pub fn api_key(mut self, api_key: impl Into<String>) -> Self {
+        self.api_key = Some(api_key.into());
+        self
+    }
+
+    /// Set the model identifier
+    pub fn model(mut self, model: impl Into<String>) -> Self {
+        self.model = Some(model.into());
+        self
+    }
+
+    /// Set the system prompt
+    pub fn system_prompt(mut self, prompt: impl Into<String>) -> Self {
+        self.system_prompt = Some(prompt.into());
+        self
+    }
+
+    /// Set the temperature
+    pub fn temperature(mut self, temp: f32) -> Self {
+        self.temperature = Some(temp);
+        self
+    }
+
+    /// Set maximum tokens
+    pub fn max_tokens(mut self, tokens: u32) -> Self {
+        self.max_tokens = Some(tokens);
+        self
+    }
+
+    /// Enable streaming responses
+    pub fn stream(mut self, enable: bool) -> Self {
+        self.stream = Some(enable);
+        self
+    }
+
+    /// Build the configuration
+    pub fn build(self) -> CloudflareConfig {
+        CloudflareConfig {
+            provider: self.provider.unwrap_or(Provider::OpenAI),
+            api_key: self.api_key.unwrap_or_default(),
+            model: self.model.unwrap_or_else(|| "gpt-4".to_string()),
+            system_prompt: self.system_prompt,
+            temperature: self.temperature.unwrap_or(0.7),
+            max_tokens: self.max_tokens,
+            stream: self.stream.unwrap_or(false),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_config_builder() {
+        let config = CloudflareConfig::builder()
+            .provider(Provider::Anthropic)
+            .api_key("test-key")
+            .model("claude-3")
+            .temperature(0.5)
+            .build();
+
+        assert!(matches!(config.provider, Provider::Anthropic));
+        assert_eq!(config.api_key, "test-key");
+        assert_eq!(config.model, "claude-3");
+        assert_eq!(config.temperature, 0.5);
+    }
+
+    #[test]
+    fn test_config_defaults() {
+        let config = CloudflareConfig::default();
+
+        assert!(matches!(config.provider, Provider::OpenAI));
+        assert_eq!(config.temperature, 0.7);
+        assert!(!config.stream);
+    }
+}

--- a/crates/cloudflare/src/error.rs
+++ b/crates/cloudflare/src/error.rs
@@ -1,0 +1,60 @@
+//! Error types for Cloudflare Workers agent
+
+use thiserror::Error;
+
+/// Errors that can occur when using the Cloudflare agent
+#[derive(Error, Debug)]
+pub enum CloudflareError {
+    /// HTTP request failed
+    #[error("HTTP request failed: {0}")]
+    HttpError(String),
+
+    /// Failed to parse response
+    #[error("Failed to parse response: {0}")]
+    ParseError(String),
+
+    /// Provider API returned an error
+    #[error("Provider error: {0}")]
+    ProviderError(String),
+
+    /// Configuration error
+    #[error("Configuration error: {0}")]
+    ConfigError(String),
+
+    /// KV store error
+    #[error("KV store error: {0}")]
+    KvError(String),
+
+    /// Serialization error
+    #[error("Serialization error: {0}")]
+    SerializationError(String),
+
+    /// Stream error
+    #[error("Stream error: {0}")]
+    StreamError(String),
+
+    /// Worker error
+    #[error("Worker error: {0}")]
+    WorkerError(String),
+}
+
+impl From<worker::Error> for CloudflareError {
+    fn from(err: worker::Error) -> Self {
+        CloudflareError::WorkerError(err.to_string())
+    }
+}
+
+impl From<serde_json::Error> for CloudflareError {
+    fn from(err: serde_json::Error) -> Self {
+        CloudflareError::SerializationError(err.to_string())
+    }
+}
+
+impl From<rust_ai_agents_llm_client::LlmClientError> for CloudflareError {
+    fn from(err: rust_ai_agents_llm_client::LlmClientError) -> Self {
+        CloudflareError::ProviderError(err.to_string())
+    }
+}
+
+/// Result type for Cloudflare agent operations
+pub type Result<T> = std::result::Result<T, CloudflareError>;

--- a/crates/cloudflare/src/http.rs
+++ b/crates/cloudflare/src/http.rs
@@ -1,0 +1,117 @@
+//! HTTP client for Cloudflare Workers using fetch API
+
+use crate::error::{CloudflareError, Result};
+use rust_ai_agents_llm_client::{HttpRequest, LlmResponse, Provider, ResponseParser};
+use worker::Fetch;
+
+/// HTTP client that uses Cloudflare Workers' fetch API
+pub struct CloudflareHttpClient;
+
+impl CloudflareHttpClient {
+    /// Execute an HTTP request using the Workers fetch API
+    pub async fn execute(request: HttpRequest) -> Result<LlmResponse> {
+        let mut headers = worker::Headers::new();
+        for (key, value) in &request.headers {
+            headers
+                .set(key, value)
+                .map_err(|e| CloudflareError::HttpError(e.to_string()))?;
+        }
+
+        let mut init = worker::RequestInit::new();
+        init.with_method(worker::Method::Post);
+        init.with_headers(headers);
+        init.with_body(Some(wasm_bindgen::JsValue::from_str(&request.body)));
+
+        let worker_request = worker::Request::new_with_init(&request.url, &init)
+            .map_err(|e| CloudflareError::HttpError(e.to_string()))?;
+
+        let mut response = Fetch::Request(worker_request)
+            .send()
+            .await
+            .map_err(|e| CloudflareError::HttpError(e.to_string()))?;
+
+        let status = response.status_code();
+        let body = response
+            .text()
+            .await
+            .map_err(|e| CloudflareError::HttpError(e.to_string()))?;
+
+        if status != 200 {
+            return Err(CloudflareError::ProviderError(format!(
+                "HTTP {}: {}",
+                status, body
+            )));
+        }
+
+        // Parse the response using the shared parser
+        let provider = extract_provider_from_url(&request.url);
+        let llm_response = ResponseParser::parse(provider, &body)?;
+
+        Ok(llm_response)
+    }
+
+    /// Execute a streaming HTTP request
+    pub async fn execute_stream(request: HttpRequest) -> Result<worker::Response> {
+        let mut headers = worker::Headers::new();
+        for (key, value) in &request.headers {
+            headers
+                .set(key, value)
+                .map_err(|e| CloudflareError::HttpError(e.to_string()))?;
+        }
+
+        let mut init = worker::RequestInit::new();
+        init.with_method(worker::Method::Post);
+        init.with_headers(headers);
+        init.with_body(Some(wasm_bindgen::JsValue::from_str(&request.body)));
+
+        let worker_request = worker::Request::new_with_init(&request.url, &init)
+            .map_err(|e| CloudflareError::HttpError(e.to_string()))?;
+
+        let response = Fetch::Request(worker_request)
+            .send()
+            .await
+            .map_err(|e| CloudflareError::HttpError(e.to_string()))?;
+
+        let status = response.status_code();
+        if status != 200 {
+            return Err(CloudflareError::ProviderError(format!(
+                "HTTP {} error",
+                status
+            )));
+        }
+
+        Ok(response)
+    }
+}
+
+/// Extract provider from URL for response parsing
+fn extract_provider_from_url(url: &str) -> Provider {
+    if url.contains("anthropic") {
+        Provider::Anthropic
+    } else if url.contains("openrouter") {
+        Provider::OpenRouter
+    } else {
+        Provider::OpenAI
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_provider() {
+        assert!(matches!(
+            extract_provider_from_url("https://api.anthropic.com/v1/messages"),
+            Provider::Anthropic
+        ));
+        assert!(matches!(
+            extract_provider_from_url("https://openrouter.ai/api/v1/chat"),
+            Provider::OpenRouter
+        ));
+        assert!(matches!(
+            extract_provider_from_url("https://api.openai.com/v1/chat/completions"),
+            Provider::OpenAI
+        ));
+    }
+}

--- a/crates/cloudflare/src/kv.rs
+++ b/crates/cloudflare/src/kv.rs
@@ -1,0 +1,173 @@
+//! KV Store integration for conversation persistence
+
+use crate::error::{CloudflareError, Result};
+use rust_ai_agents_llm_client::Message;
+use serde::{Deserialize, Serialize};
+use worker::kv::KvStore as WorkerKvStore;
+
+/// Wrapper around Cloudflare KV for conversation storage
+pub struct KvStore {
+    kv: WorkerKvStore,
+    /// TTL for conversation entries in seconds (default: 24 hours)
+    ttl: u64,
+}
+
+impl KvStore {
+    /// Create a new KV store wrapper
+    pub fn new(kv: WorkerKvStore) -> Self {
+        Self {
+            kv,
+            ttl: 86400, // 24 hours default
+        }
+    }
+
+    /// Set custom TTL for conversation entries
+    pub fn with_ttl(mut self, ttl_seconds: u64) -> Self {
+        self.ttl = ttl_seconds;
+        self
+    }
+
+    /// Get conversation history for a session
+    pub async fn get_conversation(&self, session_id: &str) -> Result<Vec<Message>> {
+        let key = format!("conversation:{}", session_id);
+
+        match self.kv.get(&key).text().await {
+            Ok(Some(data)) => {
+                let conversation: Conversation = serde_json::from_str(&data)
+                    .map_err(|e| CloudflareError::KvError(e.to_string()))?;
+                Ok(conversation.messages)
+            }
+            Ok(None) => Ok(Vec::new()),
+            Err(e) => Err(CloudflareError::KvError(e.to_string())),
+        }
+    }
+
+    /// Save conversation history for a session
+    pub async fn save_conversation(&self, session_id: &str, messages: &[Message]) -> Result<()> {
+        let key = format!("conversation:{}", session_id);
+        let conversation = Conversation {
+            messages: messages.to_vec(),
+            updated_at: chrono_now(),
+        };
+
+        let data = serde_json::to_string(&conversation)
+            .map_err(|e| CloudflareError::KvError(e.to_string()))?;
+
+        self.kv
+            .put(&key, data)
+            .map_err(|e| CloudflareError::KvError(e.to_string()))?
+            .expiration_ttl(self.ttl)
+            .execute()
+            .await
+            .map_err(|e| CloudflareError::KvError(e.to_string()))?;
+
+        Ok(())
+    }
+
+    /// Append a message to conversation history
+    pub async fn append_message(&self, session_id: &str, message: Message) -> Result<()> {
+        let mut messages = self.get_conversation(session_id).await?;
+        messages.push(message);
+        self.save_conversation(session_id, &messages).await
+    }
+
+    /// Clear conversation history for a session
+    pub async fn clear_conversation(&self, session_id: &str) -> Result<()> {
+        let key = format!("conversation:{}", session_id);
+        self.kv
+            .delete(&key)
+            .await
+            .map_err(|e| CloudflareError::KvError(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Get session metadata
+    pub async fn get_metadata(&self, session_id: &str) -> Result<Option<SessionMetadata>> {
+        let key = format!("metadata:{}", session_id);
+
+        match self.kv.get(&key).text().await {
+            Ok(Some(data)) => {
+                let metadata: SessionMetadata = serde_json::from_str(&data)
+                    .map_err(|e| CloudflareError::KvError(e.to_string()))?;
+                Ok(Some(metadata))
+            }
+            Ok(None) => Ok(None),
+            Err(e) => Err(CloudflareError::KvError(e.to_string())),
+        }
+    }
+
+    /// Save session metadata
+    pub async fn save_metadata(&self, session_id: &str, metadata: &SessionMetadata) -> Result<()> {
+        let key = format!("metadata:{}", session_id);
+        let data =
+            serde_json::to_string(metadata).map_err(|e| CloudflareError::KvError(e.to_string()))?;
+
+        self.kv
+            .put(&key, data)
+            .map_err(|e| CloudflareError::KvError(e.to_string()))?
+            .expiration_ttl(self.ttl)
+            .execute()
+            .await
+            .map_err(|e| CloudflareError::KvError(e.to_string()))?;
+
+        Ok(())
+    }
+}
+
+/// Stored conversation structure
+#[derive(Debug, Serialize, Deserialize)]
+struct Conversation {
+    messages: Vec<Message>,
+    updated_at: String,
+}
+
+/// Session metadata for tracking
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionMetadata {
+    /// Session identifier
+    pub session_id: String,
+    /// Total tokens used in session
+    pub total_tokens: u32,
+    /// Number of messages exchanged
+    pub message_count: u32,
+    /// When the session was created
+    pub created_at: String,
+    /// When the session was last updated
+    pub updated_at: String,
+    /// Custom metadata
+    pub custom: Option<serde_json::Value>,
+}
+
+impl SessionMetadata {
+    /// Create new session metadata
+    pub fn new(session_id: impl Into<String>) -> Self {
+        let now = chrono_now();
+        Self {
+            session_id: session_id.into(),
+            total_tokens: 0,
+            message_count: 0,
+            created_at: now.clone(),
+            updated_at: now,
+            custom: None,
+        }
+    }
+
+    /// Update token count
+    pub fn add_tokens(&mut self, tokens: u32) {
+        self.total_tokens += tokens;
+        self.updated_at = chrono_now();
+    }
+
+    /// Increment message count
+    pub fn increment_messages(&mut self) {
+        self.message_count += 1;
+        self.updated_at = chrono_now();
+    }
+}
+
+/// Get current timestamp as ISO string (WASM-compatible)
+fn chrono_now() -> String {
+    // In WASM, we use js_sys for time
+    let now = js_sys::Date::new_0();
+    now.to_iso_string().as_string().unwrap_or_default()
+}

--- a/crates/cloudflare/src/lib.rs
+++ b/crates/cloudflare/src/lib.rs
@@ -1,0 +1,59 @@
+//! # Cloudflare Workers Support for Rust AI Agents
+//!
+//! This crate provides Cloudflare Workers-native AI agent functionality with:
+//! - Multiple LLM provider support (OpenAI, Anthropic, OpenRouter)
+//! - KV store integration for conversation persistence
+//! - Streaming responses using Response streams
+//! - Request/response handling for Worker routes
+//!
+//! ## Quick Start
+//!
+//! ```rust,ignore
+//! use rust_ai_agents_cloudflare::{CloudflareAgent, CloudflareConfig, Provider};
+//! use worker::*;
+//!
+//! #[event(fetch)]
+//! async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
+//!     let config = CloudflareConfig::builder()
+//!         .provider(Provider::Anthropic)
+//!         .api_key(env.secret("ANTHROPIC_API_KEY")?.to_string())
+//!         .model("claude-3-5-sonnet-20241022")
+//!         .build();
+//!
+//!     let agent = CloudflareAgent::new(config);
+//!
+//!     let response = agent.chat("Hello!").await?;
+//!     Response::ok(response.content)
+//! }
+//! ```
+//!
+//! ## With KV Persistence
+//!
+//! ```rust,ignore
+//! use rust_ai_agents_cloudflare::{CloudflareAgent, KvStore};
+//!
+//! let kv = env.kv("CONVERSATIONS")?;
+//! let agent = CloudflareAgent::new(config)
+//!     .with_kv(KvStore::new(kv));
+//!
+//! // Conversation history is automatically persisted
+//! let response = agent.chat_with_session("session-123", "Hello!").await?;
+//! ```
+
+mod agent;
+mod config;
+mod error;
+mod http;
+mod kv;
+mod streaming;
+
+pub use agent::CloudflareAgent;
+pub use config::{CloudflareConfig, CloudflareConfigBuilder};
+pub use error::CloudflareError;
+pub use http::CloudflareHttpClient;
+pub use kv::KvStore;
+pub use rust_ai_agents_llm_client::{Message, Provider, Role};
+pub use streaming::{StreamChunk, StreamingResponse};
+
+/// Re-export worker types for convenience
+pub use worker::{Env, Request, Response, Result};

--- a/crates/cloudflare/src/streaming.rs
+++ b/crates/cloudflare/src/streaming.rs
@@ -1,0 +1,224 @@
+//! Streaming response support for Cloudflare Workers
+
+use rust_ai_agents_llm_client::Provider;
+use serde::{Deserialize, Serialize};
+
+/// A chunk from a streaming response
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StreamChunk {
+    /// Text content delta
+    pub content: String,
+    /// Whether this is the final chunk
+    pub done: bool,
+    /// Token usage (only on final chunk)
+    pub usage: Option<StreamUsage>,
+}
+
+/// Token usage information
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StreamUsage {
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub total_tokens: u32,
+}
+
+/// Iterator over streaming response chunks
+pub struct StreamingResponse {
+    buffer: String,
+    provider: Provider,
+    done: bool,
+}
+
+impl StreamingResponse {
+    /// Create a new streaming response parser
+    pub fn new(provider: Provider) -> Self {
+        Self {
+            buffer: String::new(),
+            provider,
+            done: false,
+        }
+    }
+
+    /// Process incoming data and extract chunks
+    pub fn process(&mut self, data: &str) -> Vec<StreamChunk> {
+        self.buffer.push_str(data);
+        let mut chunks = Vec::new();
+
+        // Process complete SSE lines
+        while let Some(pos) = self.buffer.find("\n\n") {
+            let line = self.buffer[..pos].to_string();
+            self.buffer = self.buffer[pos + 2..].to_string();
+
+            if let Some(chunk) = self.parse_sse_line(&line) {
+                if chunk.done {
+                    self.done = true;
+                }
+                chunks.push(chunk);
+            }
+        }
+
+        chunks
+    }
+
+    /// Check if the stream is complete
+    pub fn is_done(&self) -> bool {
+        self.done
+    }
+
+    /// Parse a single SSE line
+    fn parse_sse_line(&self, line: &str) -> Option<StreamChunk> {
+        // Handle data: prefix
+        let data = line.strip_prefix("data: ")?;
+
+        // Handle [DONE] marker
+        if data.trim() == "[DONE]" {
+            return Some(StreamChunk {
+                content: String::new(),
+                done: true,
+                usage: None,
+            });
+        }
+
+        // Parse JSON based on provider
+        match self.provider {
+            Provider::OpenAI | Provider::OpenRouter => self.parse_openai_chunk(data),
+            Provider::Anthropic => self.parse_anthropic_chunk(data),
+        }
+    }
+
+    /// Parse OpenAI/OpenRouter format chunk
+    fn parse_openai_chunk(&self, data: &str) -> Option<StreamChunk> {
+        #[derive(Deserialize)]
+        struct OpenAiChunk {
+            choices: Vec<OpenAiChoice>,
+            usage: Option<OpenAiUsage>,
+        }
+
+        #[derive(Deserialize)]
+        struct OpenAiChoice {
+            delta: OpenAiDelta,
+            finish_reason: Option<String>,
+        }
+
+        #[derive(Deserialize)]
+        struct OpenAiDelta {
+            content: Option<String>,
+        }
+
+        #[derive(Deserialize)]
+        struct OpenAiUsage {
+            prompt_tokens: u32,
+            completion_tokens: u32,
+            total_tokens: u32,
+        }
+
+        let chunk: OpenAiChunk = serde_json::from_str(data).ok()?;
+        let choice = chunk.choices.first()?;
+
+        let done = choice.finish_reason.is_some();
+        let content = choice.delta.content.clone().unwrap_or_default();
+        let usage = chunk.usage.map(|u| StreamUsage {
+            prompt_tokens: u.prompt_tokens,
+            completion_tokens: u.completion_tokens,
+            total_tokens: u.total_tokens,
+        });
+
+        Some(StreamChunk {
+            content,
+            done,
+            usage,
+        })
+    }
+
+    /// Parse Anthropic format chunk
+    fn parse_anthropic_chunk(&self, data: &str) -> Option<StreamChunk> {
+        #[derive(Deserialize)]
+        struct AnthropicEvent {
+            #[serde(rename = "type")]
+            event_type: String,
+            delta: Option<AnthropicDelta>,
+            usage: Option<AnthropicUsage>,
+        }
+
+        #[derive(Deserialize)]
+        struct AnthropicDelta {
+            #[serde(rename = "type")]
+            _delta_type: Option<String>,
+            text: Option<String>,
+        }
+
+        #[derive(Deserialize)]
+        struct AnthropicUsage {
+            input_tokens: u32,
+            output_tokens: u32,
+        }
+
+        let event: AnthropicEvent = serde_json::from_str(data).ok()?;
+
+        match event.event_type.as_str() {
+            "content_block_delta" => {
+                let text = event.delta.and_then(|d| d.text).unwrap_or_default();
+                Some(StreamChunk {
+                    content: text,
+                    done: false,
+                    usage: None,
+                })
+            }
+            "message_stop" => Some(StreamChunk {
+                content: String::new(),
+                done: true,
+                usage: event.usage.map(|u| StreamUsage {
+                    prompt_tokens: u.input_tokens,
+                    completion_tokens: u.output_tokens,
+                    total_tokens: u.input_tokens + u.output_tokens,
+                }),
+            }),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_openai_chunk_parsing() {
+        let mut stream = StreamingResponse::new(Provider::OpenAI);
+
+        let data = r#"data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}
+
+"#;
+
+        let chunks = stream.process(data);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].content, "Hello");
+        assert!(!chunks[0].done);
+    }
+
+    #[test]
+    fn test_done_marker() {
+        let mut stream = StreamingResponse::new(Provider::OpenAI);
+
+        let data = "data: [DONE]\n\n";
+        let chunks = stream.process(data);
+
+        assert_eq!(chunks.len(), 1);
+        assert!(chunks[0].done);
+        assert!(stream.is_done());
+    }
+
+    #[test]
+    fn test_anthropic_chunk_parsing() {
+        let mut stream = StreamingResponse::new(Provider::Anthropic);
+
+        let data = r#"data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"Hi"}}
+
+"#;
+
+        let chunks = stream.process(data);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].content, "Hi");
+        assert!(!chunks[0].done);
+    }
+}

--- a/crates/cloudflare/worker-template/lib.rs
+++ b/crates/cloudflare/worker-template/lib.rs
@@ -1,0 +1,141 @@
+//! Basic Cloudflare Worker example with AI chat
+//!
+//! Deploy with:
+//! ```bash
+//! cd crates/cloudflare
+//! wrangler deploy
+//! ```
+//!
+//! Set your API key:
+//! ```bash
+//! wrangler secret put ANTHROPIC_API_KEY
+//! ```
+
+use rust_ai_agents_cloudflare::{CloudflareAgent, CloudflareConfig, KvStore, Provider};
+use worker::*;
+
+#[event(fetch)]
+async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
+    // Set up panic hook for better error messages
+    console_error_panic_hook::set_once();
+
+    // Route handling
+    let router = Router::new();
+
+    router
+        .post_async("/chat", |mut req, ctx| async move {
+            handle_chat(req, ctx).await
+        })
+        .post_async("/chat/:session_id", |mut req, ctx| async move {
+            handle_chat_with_session(req, ctx).await
+        })
+        .get("/health", |_, _| Response::ok("OK"))
+        .run(req, env)
+        .await
+}
+
+/// Handle a simple chat request (no session persistence)
+async fn handle_chat(mut req: Request, ctx: RouteContext<()>) -> Result<Response> {
+    // Parse request body
+    let body: ChatRequest = req.json().await?;
+
+    // Get API key from secrets
+    let api_key = ctx.secret("ANTHROPIC_API_KEY")?.to_string();
+
+    // Get model from env or use default
+    let model = ctx
+        .var("DEFAULT_MODEL")
+        .map(|v| v.to_string())
+        .unwrap_or_else(|_| "claude-3-5-sonnet-20241022".to_string());
+
+    // Create agent configuration
+    let config = CloudflareConfig::builder()
+        .provider(Provider::Anthropic)
+        .api_key(api_key)
+        .model(model)
+        .system_prompt("You are a helpful AI assistant.")
+        .temperature(0.7)
+        .build();
+
+    // Create agent and chat
+    let mut agent = CloudflareAgent::new(config);
+
+    match agent.chat(&body.message).await {
+        Ok(response) => {
+            let chat_response = ChatResponse {
+                content: response.content,
+                usage: response.usage.map(|u| UsageResponse {
+                    prompt_tokens: u.prompt_tokens,
+                    completion_tokens: u.completion_tokens,
+                    total_tokens: u.total_tokens,
+                }),
+            };
+            Response::from_json(&chat_response)
+        }
+        Err(e) => Response::error(format!("Chat error: {}", e), 500),
+    }
+}
+
+/// Handle a chat request with session persistence
+async fn handle_chat_with_session(mut req: Request, ctx: RouteContext<()>) -> Result<Response> {
+    // Get session ID from path
+    let session_id = ctx.param("session_id").unwrap_or("default");
+
+    // Parse request body
+    let body: ChatRequest = req.json().await?;
+
+    // Get API key and KV store
+    let api_key = ctx.secret("ANTHROPIC_API_KEY")?.to_string();
+    let kv = ctx.kv("CONVERSATIONS")?;
+
+    let model = ctx
+        .var("DEFAULT_MODEL")
+        .map(|v| v.to_string())
+        .unwrap_or_else(|_| "claude-3-5-sonnet-20241022".to_string());
+
+    // Create agent with KV persistence
+    let config = CloudflareConfig::builder()
+        .provider(Provider::Anthropic)
+        .api_key(api_key)
+        .model(model)
+        .system_prompt("You are a helpful AI assistant.")
+        .build();
+
+    let mut agent = CloudflareAgent::new(config).with_kv(KvStore::new(kv));
+
+    match agent.chat_with_session(session_id, &body.message).await {
+        Ok(response) => {
+            let chat_response = ChatResponse {
+                content: response.content,
+                usage: response.usage.map(|u| UsageResponse {
+                    prompt_tokens: u.prompt_tokens,
+                    completion_tokens: u.completion_tokens,
+                    total_tokens: u.total_tokens,
+                }),
+            };
+            Response::from_json(&chat_response)
+        }
+        Err(e) => Response::error(format!("Chat error: {}", e), 500),
+    }
+}
+
+/// Request body for chat endpoint
+#[derive(serde::Deserialize)]
+struct ChatRequest {
+    message: String,
+}
+
+/// Response body for chat endpoint
+#[derive(serde::Serialize)]
+struct ChatResponse {
+    content: String,
+    usage: Option<UsageResponse>,
+}
+
+/// Token usage in response
+#[derive(serde::Serialize)]
+struct UsageResponse {
+    prompt_tokens: u32,
+    completion_tokens: u32,
+    total_tokens: u32,
+}

--- a/crates/cloudflare/wrangler.toml.example
+++ b/crates/cloudflare/wrangler.toml.example
@@ -1,0 +1,53 @@
+# Cloudflare Workers configuration for rust-ai-agents
+# Copy this to wrangler.toml and customize for your deployment
+
+name = "ai-agent-worker"
+main = "build/worker/shim.mjs"
+compatibility_date = "2024-01-01"
+
+# Build configuration for Rust WASM
+[build]
+command = "cargo install -q worker-build && worker-build --release"
+
+# KV Namespaces for conversation persistence
+[[kv_namespaces]]
+binding = "CONVERSATIONS"
+id = "your-kv-namespace-id"
+preview_id = "your-preview-kv-namespace-id"
+
+# Secrets (configure via `wrangler secret put`)
+# - OPENAI_API_KEY
+# - ANTHROPIC_API_KEY
+# - OPENROUTER_API_KEY
+
+# Environment variables
+[vars]
+ENVIRONMENT = "production"
+DEFAULT_MODEL = "claude-3-5-sonnet-20241022"
+DEFAULT_PROVIDER = "anthropic"
+
+# Development environment
+[env.dev]
+name = "ai-agent-worker-dev"
+[env.dev.vars]
+ENVIRONMENT = "development"
+
+# Staging environment
+[env.staging]
+name = "ai-agent-worker-staging"
+[env.staging.vars]
+ENVIRONMENT = "staging"
+
+# Route configuration (optional)
+# routes = [
+#   { pattern = "api.example.com/chat/*", zone_name = "example.com" }
+# ]
+
+# Durable Objects (for stateful agents - optional)
+# [[durable_objects.bindings]]
+# name = "AGENT_SESSIONS"
+# class_name = "AgentSession"
+#
+# [[migrations]]
+# tag = "v1"
+# new_classes = ["AgentSession"]


### PR DESCRIPTION
## Summary

Adds a new `rust-ai-agents-cloudflare` crate for running AI agents on Cloudflare Workers edge computing platform.

## Features

- **CloudflareAgent**: Main agent with chat, streaming, and session persistence
- **KV Store Integration**: Conversation history persistence using Cloudflare KV
- **HTTP Client**: Uses Workers fetch API for LLM requests
- **SSE Streaming**: Parse streaming responses from OpenAI/Anthropic
- **Multi-Provider**: Support for OpenAI, Anthropic, and OpenRouter
- **Configuration Builder**: Fluent API for agent configuration

## New Files

```
crates/cloudflare/
├── Cargo.toml
├── src/
│   ├── lib.rs          # Main exports
│   ├── agent.rs        # CloudflareAgent
│   ├── config.rs       # Configuration builder
│   ├── error.rs        # Error types
│   ├── http.rs         # HTTP client using fetch API
│   ├── kv.rs           # KV store wrapper
│   └── streaming.rs    # SSE parser
├── worker-template/
│   └── lib.rs          # Example worker implementation
└── wrangler.toml.example
```

## Usage

```rust
use rust_ai_agents_cloudflare::{CloudflareAgent, CloudflareConfig, Provider};

let config = CloudflareConfig::builder()
    .provider(Provider::Anthropic)
    .api_key(api_key)
    .model("claude-3-5-sonnet-20241022")
    .system_prompt("You are helpful.")
    .build();

let mut agent = CloudflareAgent::new(config);
let response = agent.chat("Hello!").await?;
```

## Testing

- 9 unit tests passing
- Tests cover agent creation, config defaults, streaming parsing

Closes #12